### PR TITLE
Support older git versions

### DIFF
--- a/lib/get-last-release.js
+++ b/lib/get-last-release.js
@@ -1,6 +1,7 @@
 const semver = require('semver');
+const pLocate = require('p-locate');
 const debug = require('debug')('semantic-release:git');
-const {unshallow, gitTags} = require('./git');
+const {unshallow, gitTags, isRefInHistory} = require('./git');
 
 /**
  * Last release.
@@ -25,11 +26,11 @@ const {unshallow, gitTags} = require('./git');
 module.exports = async logger => {
   // Unshallow the repo in order to get all the tags
   await unshallow();
-  const tags = (await gitTags()).filter(tag => semver.valid(semver.clean(tag))).sort(semver.compare);
+  const tags = (await gitTags()).filter(tag => semver.valid(semver.clean(tag))).sort((a, b) => -semver.compare(a, b));
   debug('found tags: %o', tags);
 
   if (tags.length > 0) {
-    const tag = tags[tags.length - 1];
+    const tag = await pLocate(tags, tag => isRefInHistory(tag), {concurrency: 1, preserveOrder: true});
     logger.log('Found git tag version %s', tag);
     return {gitHead: tag, version: semver.valid(semver.clean(tag))};
   }

--- a/lib/git.js
+++ b/lib/git.js
@@ -3,12 +3,12 @@ const SemanticReleaseError = require('@semantic-release/error');
 const debug = require('debug')('semantic-release:git');
 
 /**
- * @return {Array<String>} List of git tags in the history of the current branch.
+ * @return {Array<String>} List of git tags.
  * @throws {Error} If the `git` command fails.
  */
 async function gitTags() {
   try {
-    return (await execa.stdout('git', ['tag', '--merge', 'HEAD']))
+    return (await execa.stdout('git', ['tag']))
       .split('\n')
       .map(tag => tag.trim())
       .filter(tag => Boolean(tag));
@@ -16,6 +16,17 @@ async function gitTags() {
     debug(err);
     throw new Error(err.stderr);
   }
+}
+
+/**
+ * Verify if the `ref` is in the direct history of the current branch.
+ *
+ * @param {string} ref The reference to look for.
+ *
+ * @return {boolean} `true` if the reference is in the history of the current branch, `false` otherwise.
+ */
+async function isRefInHistory(ref) {
+  return (await execa('git', ['merge-base', '--is-ancestor', ref, 'HEAD'], {reject: false})).code === 0;
 }
 
 /**
@@ -168,4 +179,5 @@ module.exports = {
   commit,
   tag,
   push,
+  isRefInHistory,
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "git-url-parse": "^7.0.1",
     "lodash": "^4.17.4",
     "micromatch": "^3.1.4",
+    "p-locate": "^2.0.0",
     "p-reduce": "^1.0.0",
     "semver": "^5.4.1"
   },

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -5,8 +5,6 @@ import {unshallow, gitTags, add, getModifiedFiles, config, commit, tag, gitHead,
 import {
   gitRepo,
   gitCommit,
-  gitCheckout,
-  gitTagVersion,
   gitShallowClone,
   gitGetCommit,
   gitGetConfig,
@@ -47,30 +45,6 @@ test.serial('Do not throw error when unshallow a complete repository', async t =
   // Add commits to the master branch
   await gitCommit('First');
   await t.notThrows(unshallow());
-});
-
-test.serial('Get the tags in the history of the current branch', async t => {
-  // Create a git repository, set the current working directory at the root of the repo
-  await gitRepo();
-  // Add commit to the master branch
-  await gitCommit('First');
-  // Create the tag corresponding to version 1.0.0
-  await gitTagVersion('v1.0.0');
-  // Create the new branch 'other-branch' from master
-  await gitCheckout('other-branch');
-  // Add commit to the 'other-branch' branch
-  await gitCommit('Second');
-  // Create the tag corresponding to version 2.0.0
-  await gitTagVersion('v2.0.0');
-  // Checkout master
-  await gitCheckout('master', false);
-  // Add another commit to the master branch
-  await gitCommit('Third');
-  // Create the tag corresponding to version 3.0.0
-  await gitTagVersion('v3.0.0');
-
-  // Verify the git tag v2.0.0 is not returned as it is not accessible on the current branch
-  t.deepEqual(await gitTags(), ['v1.0.0', 'v3.0.0']);
 });
 
 test.serial('Throws error if obtaining the tags fails', async t => {


### PR DESCRIPTION
Check if a tag is in the branch history with `git merge-base` as the `--merge` options of the `git tag` command is available only since `git` version `2.7.0`.

Fix semantic-release/semantic-release#559