### PR TITLE
Add log details for git commands

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -101,6 +101,7 @@ async function push(origin, branch) {
   try {
     await execa('git', ['push', '--tags', origin, `HEAD:${branch}`]);
   } catch (err) {
+    debug(err);
     throw new Error(`An error occured during the git push to the remote branch ${branch}`);
   }
 }


### PR DESCRIPTION
Without this it is *very* hard to understand why the CI environment isn't set up correctly.