### PR TITLE
feat: add package-lock.json to list of automatically detected files

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -11,6 +11,7 @@ const {getModifiedFiles, add, config, deleteHeadTag, commit, tag, push} = requir
 
 const CHANGELOG = 'CHANGELOG.md';
 const PKG_JSON = 'package.json';
+const PKG_LOCK = 'package-lock.json';
 const SKW_JSON = 'npm-shrinkwrap.json';
 
 /**
@@ -47,6 +48,10 @@ module.exports = async (pluginConfig, {branch, repositoryUrl}, lastRelease, next
   if (isUndefined(assets) && (await pathExists(PKG_JSON))) {
     logger.log('Add %s to the release commit', PKG_JSON);
     patterns.push(PKG_JSON);
+  }
+  if (isUndefined(assets) && (await pathExists(PKG_LOCK))) {
+    logger.log('Add %s to the release commit', PKG_LOCK);
+    patterns.push(PKG_LOCK);
   }
   if (isUndefined(assets) && (await pathExists(SKW_JSON))) {
     logger.log('Add %s to the release commit', SKW_JSON);


### PR DESCRIPTION
Hi there!

~~npm 5.0 (released in late May of 2017) introduced a new lockfile format to replace `npm-shrinkwrap`, which is instead stored in a file called `package-lock.json`.~~ *(EDIT: I now realize that this explanation isn't exactly correct, although keeping both updated is still something which I believe should be done.)* This PR adds `package-lock.json` to the list of automatically detected files to update, as it also contains the current version number of the package and this will be bumped by `npm version`. Since the latest versions of npm now create `package-lock` files rather than `npm-shrinkwrap` files, it seems appropriate to include both in the list of files that are updated by default.

Cheers!