### PR TITLE
feat: log all git command errors

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -7,15 +7,10 @@ const debug = require('debug')('semantic-release:git');
  * @throws {Error} If the `git` command fails.
  */
 async function gitTags() {
-  try {
-    return (await execa.stdout('git', ['tag']))
-      .split('\n')
-      .map(tag => tag.trim())
-      .filter(tag => Boolean(tag));
-  } catch (err) {
-    debug(err);
-    throw new Error(err.stderr);
-  }
+  return (await execa.stdout('git', ['tag']))
+    .split('\n')
+    .map(tag => tag.trim())
+    .filter(tag => Boolean(tag));
 }
 
 /**
@@ -97,24 +92,14 @@ async function tag(tagName) {
  * @throws {Error} if the push failed.
  */
 async function push(origin, branch) {
-  // Do not log result or error to not reveal credentials
-  try {
-    await execa('git', ['push', '--tags', origin, `HEAD:${branch}`]);
-  } catch (err) {
-    throw new Error(`An error occured during the git push to the remote branch ${branch}`);
-  }
+  await execa('git', ['push', '--tags', origin, `HEAD:${branch}`]);
 }
 
 /**
  * @return {String} The sha of the head commit on the local repository
  */
 async function gitHead() {
-  try {
-    return await execa.stdout('git', ['rev-parse', 'HEAD']);
-  } catch (err) {
-    debug(err);
-    throw new Error(err.stderr);
-  }
+  return execa.stdout('git', ['rev-parse', 'HEAD']);
 }
 
 /**
@@ -126,7 +111,6 @@ async function gitHead() {
  * @return {Boolean} `true` is authorized to push, `false` otherwise.
  */
 async function verifyAuth(origin, branch) {
-  // Do not log result or error to not reveal credentials
   return (await execa('git', ['push', '--dry-run', origin, `HEAD:${branch}`], {reject: false})).code === 0;
 }
 

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -153,16 +153,6 @@ test.serial('Push tag and commit to remote repository', async t => {
   t.is((await gitRemoteTagHead(repo, 'tag_name')).substring(0, 7), hash);
 });
 
-test.serial('If push fails returns and Error without reference to the repository URL', async t => {
-  // Create a git repository with a remote, set the current working directory at the root of the repo
-  await gitRepo(true);
-  await gitCommit('Test commit');
-  await tag('tag_name');
-
-  const error = await t.throws(push('http://wrongurl.com/repo.git', 'master'), Error);
-  t.is(error.message, 'An error occured during the git push to the remote branch master');
-});
-
 test.serial('Delete local and remote tag if they reference the local HEAD', async t => {
   // Create a git repository with a remote, set the current working directory at the root of the repo
   const repo = await gitRepo(true);


### PR DESCRIPTION
Can safely log any `git` output since semantic-release/semantic-release#618 got merged.

Fix #21