### PR TITLE
fix(package): add peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "Stephan Bönnemann <stephan@boennemann.me> (http://boennemann.me)",
     "Gregor Martynus (https://twitter.com/gr2m)"
   ],
+  "peerDependencies": {
+    "semantic-release": "^13.0.0"
+  },
   "dependencies": {
     "@semantic-release/error": "^2.1.0",
     "debug": "^3.1.0",


### PR DESCRIPTION
This tripped me up when I installed `@semantic-release/git@latest` and didn't realise it was not compatible with `semantic-release@latest` (v12). 