### PR TITLE
feat: change `publish` hook to `prepare`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Set of [Semantic-release](https://github.com/semantic-release/semantic-release) 
 
 Verify the access to the remote Git repository, the commit `message` format and the `assets` option configuration.
 
-## publish
+## prepare
 
-Publish a release commit, including configurable files.
+Create a release commit, including configurable files.
 
 ## Configuration
 
@@ -83,42 +83,30 @@ Options can be set within the plugin definition in the Semantic-release configur
 ```json
 {
   "release": {
-    "publish": [
+    "prepare": [
       "@semantic-release/npm",
       {
         "path": "@semantic-release/git",
         "assets": ["package.json", "dist/**/*.{js|css}", "docs"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      },
-      "@semantic-release/github"
-    ]
+      }
+    ],
+    "publish": ["@semantic-release/github"]
   }
 }
 ```
 
-When using with the [changelog](https://github.com/semantic-release/changelog), [npm](https://github.com/semantic-release/npm) or [github](https://github.com/semantic-release/github) plugins:
+When using with the [changelog](https://github.com/semantic-release/changelog) or [npm](https://github.com/semantic-release/npm) plugins:
 - The [changelog](https://github.com/semantic-release/changelog) plugin must be called first in order to update the changelog file so the [git](https://github.com/semantic-release/git) and [npm](https://github.com/semantic-release/npm) plugin can include it in the release.
 - The [npm](https://github.com/semantic-release/npm) plugin must be called second in order to update the `package.json` file so the [git](https://github.com/semantic-release/git) plugin can include it in the release commit.
-- The [github](https://github.com/semantic-release/github) plugin must be called last to create a [GitHub Release](https://help.github.com/articles/about-releases/) that reference the tag created by the [git](https://github.com/semantic-release/git) plugin.
 
-To use with the [changelog](https://github.com/semantic-release/changelog), [github](https://github.com/semantic-release/github) and [npm](https://github.com/semantic-release/npm) plugins:
-
-```json
-{
-  "release": {
-    "verifyConditions": ["@semantic-release/changelog", "@semantic-release/npm", "@semantic-release/git", "@semantic-release/github"],
-    "publish": ["@semantic-release/changelog", "@semantic-release/npm", "@semantic-release/git", "@semantic-release/github"]
-  }
-}
-```
-
-To use with [github](https://github.com/semantic-release/github):
+To use with the [changelog](https://github.com/semantic-release/changelog) and [npm](https://github.com/semantic-release/npm) plugins:
 
 ```json
 {
   "release": {
-    "verifyConditions": ["@semantic-release/git", "@semantic-release/github"],
-    "publish": ["@semantic-release/git", "@semantic-release/github"]
+    "verifyConditions": ["@semantic-release/changelog", "@semantic-release/npm", "@semantic-release/git"],
+    "prepare": ["@semantic-release/changelog", "@semantic-release/npm", "@semantic-release/git"]
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -1,29 +1,29 @@
 const {castArray} = require('lodash');
 const verifyGit = require('./lib/verify');
-const publishGit = require('./lib/publish');
+const prepareGit = require('./lib/prepare');
 
 let verified;
 
 async function verifyConditions(pluginConfig, context) {
   const {options} = context;
-  // If the Git publish plugin is used and has `assets` or `message` configured, validate them now in order to prevent any release if the configuration is wrong
-  if (options.publish) {
-    const publishPlugin =
-      castArray(options.publish).find(config => config.path && config.path === '@semantic-release/git') || {};
+  // If the Git prepare plugin is used and has `assets` or `message` configured, validate them now in order to prevent any release if the configuration is wrong
+  if (options.prepare) {
+    const preparePlugin =
+      castArray(options.prepare).find(config => config.path && config.path === '@semantic-release/git') || {};
 
-    pluginConfig.assets = pluginConfig.assets || publishPlugin.assets;
-    pluginConfig.message = pluginConfig.message || publishPlugin.message;
+    pluginConfig.assets = pluginConfig.assets || preparePlugin.assets;
+    pluginConfig.message = pluginConfig.message || preparePlugin.message;
   }
   await verifyGit(pluginConfig);
   verified = true;
 }
 
-async function publish(pluginConfig, context) {
+async function prepare(pluginConfig, context) {
   if (!verified) {
     await verifyGit(pluginConfig);
     verified = true;
   }
-  await publishGit(pluginConfig, context);
+  await prepareGit(pluginConfig, context);
 }
 
-module.exports = {verifyConditions, publish};
+module.exports = {verifyConditions, prepare};

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -13,7 +13,7 @@ const PKG_LOCK = 'package-lock.json';
 const SKW_JSON = 'npm-shrinkwrap.json';
 
 /**
- * Publish a release commit including configurable files.
+ * Prepare a release commit including configurable files.
  *
  * @param {Object} pluginConfig The plugin configuration.
  * @param {String|Array<String>} [pluginConfig.assets] Files to include in the release commit. Can be files path or globs.
@@ -88,5 +88,5 @@ module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, lastRel
 
   logger.log('Creating tag %s', nextRelease.gitTag);
   await push(repositoryUrl, branch);
-  logger.log('Published Git release: %s', nextRelease.gitTag);
+  logger.log('Prepared Git release: %s', nextRelease.gitTag);
 };

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "all": true
   },
   "peerDependencies": {
-    "semantic-release": ">=13.3.0 <15.0.0"
+    "semantic-release": ">=15.0.0 <16.0.0"
   },
   "prettier": {
     "printWidth": 120

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -40,7 +40,7 @@ test.afterEach.always(() => {
   process.chdir(cwd);
 });
 
-test.serial('Publish from a shallow clone', async t => {
+test.serial('Prepare from a shallow clone', async t => {
   process.env.GIT_EMAIL = 'user@email.com';
   process.env.GIT_USERNAME = 'user';
   const branch = 'master';
@@ -62,7 +62,7 @@ test.serial('Publish from a shallow clone', async t => {
     message: `Release version \${nextRelease.version} from branch \${branch}\n\n\${nextRelease.notes}`,
     assets: '**/*.{js,json}',
   };
-  await t.context.m.publish(pluginConfig, {logger: t.context.logger, options: {repositoryUrl, branch}, nextRelease});
+  await t.context.m.prepare(pluginConfig, {logger: t.context.logger, options: {repositoryUrl, branch}, nextRelease});
 
   t.deepEqual(await gitCommitedFiles(), ['dist/file.js', 'package.json']);
   const [commit] = await gitGetCommits();
@@ -73,7 +73,7 @@ test.serial('Publish from a shallow clone', async t => {
   t.is(commit.author.email, process.env.GIT_EMAIL);
 });
 
-test.serial('Publish from a detached head repository', async t => {
+test.serial('Prepare from a detached head repository', async t => {
   const branch = 'master';
   const repositoryUrl = await gitRepo(true);
   await outputFile('package.json', "{name: 'test-package', version: '1.0.0'}");
@@ -93,7 +93,7 @@ test.serial('Publish from a detached head repository', async t => {
     message: `Release version \${nextRelease.version} from branch \${branch}\n\n\${nextRelease.notes}`,
     assets: '**/*.{js,json}',
   };
-  await t.context.m.publish(pluginConfig, {logger: t.context.logger, options: {repositoryUrl, branch}, nextRelease});
+  await t.context.m.prepare(pluginConfig, {logger: t.context.logger, options: {repositoryUrl, branch}, nextRelease});
 
   t.deepEqual(await gitCommitedFiles(), ['dist/file.js', 'package.json']);
   const [commit] = await gitGetCommits();
@@ -106,16 +106,16 @@ test.serial('Verify authentication only on the fist call', async t => {
   const branch = 'master';
   const repositoryUrl = await gitRepo(true);
   const nextRelease = {version: '2.0.0', gitTag: 'v2.0.0'};
-  const options = {repositoryUrl, branch, publish: ['@semantic-release/npm']};
+  const options = {repositoryUrl, branch, prepare: ['@semantic-release/npm']};
 
   await t.notThrows(t.context.m.verifyConditions({}, {options, logger: t.context.logger}));
-  await t.context.m.publish({}, {logger: t.context.logger, options: {repositoryUrl, branch}, nextRelease});
+  await t.context.m.prepare({}, {logger: t.context.logger, options: {repositoryUrl, branch}, nextRelease});
 });
 
-test('Throw SemanticReleaseError if publish config is invalid', async t => {
+test('Throw SemanticReleaseError if prepare config is invalid', async t => {
   const message = 42;
   const assets = true;
-  const options = {publish: ['@semantic-release/npm', {path: '@semantic-release/git', message, assets}]};
+  const options = {prepare: ['@semantic-release/npm', {path: '@semantic-release/git', message, assets}]};
 
   const errors = [...(await t.throws(t.context.m.verifyConditions({}, {options, logger: t.context.logger})))];
 

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import {outputFile} from 'fs-extra';
 import {stub} from 'sinon';
-import publish from '../lib/publish';
+import prepare from '../lib/prepare';
 import {gitRepo, gitGetCommits, gitCommitedFiles} from './helpers/git-utils';
 
 // Save the current process.env
@@ -40,7 +40,7 @@ test.serial(
     await outputFile('package-lock.json', "{name: 'test-package'}");
     await outputFile('npm-shrinkwrap.json', "{name: 'test-package'}");
 
-    await publish(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
+    await prepare(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
 
     // Verify the remote repo has a the version referencing the same commit sha at the local head
     const [commit] = await gitGetCommits();
@@ -60,7 +60,7 @@ test.serial(
     t.deepEqual(t.context.log.args[3], ['Add %s to the release commit', 'npm-shrinkwrap.json']);
     t.deepEqual(t.context.log.args[4], ['Found %d file(s) to commit', 4]);
     t.deepEqual(t.context.log.args[5], ['Creating tag %s', nextRelease.gitTag]);
-    t.deepEqual(t.context.log.args[6], ['Published Git release: %s', nextRelease.gitTag]);
+    t.deepEqual(t.context.log.args[6], ['Prepared Git release: %s', nextRelease.gitTag]);
   }
 );
 
@@ -75,12 +75,12 @@ test.serial(
     await outputFile('package-lock.json', "{name: 'test-package'}");
     await outputFile('npm-shrinkwrap.json', "{name: 'test-package'}");
 
-    await publish(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
+    await prepare(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
 
     // Verify no files have been commited
     t.deepEqual(await gitCommitedFiles(), []);
     t.deepEqual(t.context.log.args[0], ['Creating tag %s', nextRelease.gitTag]);
-    t.deepEqual(t.context.log.args[1], ['Published Git release: %s', nextRelease.gitTag]);
+    t.deepEqual(t.context.log.args[1], ['Prepared Git release: %s', nextRelease.gitTag]);
   }
 );
 
@@ -95,7 +95,7 @@ Last release: \${lastRelease.version}
   const nextRelease = {version: '2.0.0', gitTag: 'v2.0.0', notes: 'Test release note'};
   await outputFile('CHANGELOG.md', 'Initial CHANGELOG');
 
-  await publish(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
+  await prepare(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
 
   // Verify the files that have been commited
   t.deepEqual(await gitCommitedFiles(), ['CHANGELOG.md']);
@@ -122,7 +122,7 @@ test.serial('Commit files matching the patterns in "assets"', async t => {
   await outputFile('dir2/file6.js', 'Test content');
   await outputFile('dir2/file7.css', 'Test content');
 
-  await publish(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
+  await prepare(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
 
   // Verify file2 and file1 have been commited
   // file4.js is excluded as no glob matching
@@ -151,7 +151,7 @@ test.serial('Commit files matching the patterns in "assets" as Objects', async t
   await outputFile('dir2/file6.js', 'Test content');
   await outputFile('dir2/file7.css', 'Test content');
 
-  await publish(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
+  await prepare(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
 
   // Verify file2 and file1 have been commited
   // file4.js is excluded as no glob matching
@@ -170,7 +170,7 @@ test.serial('Commit files matching the patterns in "assets" as single glob', asy
   await outputFile('dist/file1.js', 'Test content');
   await outputFile('dist/file2.css', 'Test content');
 
-  await publish(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
+  await prepare(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
 
   t.deepEqual(await gitCommitedFiles(), ['dist/file1.js']);
 
@@ -184,7 +184,7 @@ test.serial('Commit files matching the patterns in "assets", including dot files
 
   await outputFile('dist/.dotfile', 'Test content');
 
-  await publish(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
+  await prepare(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
 
   t.deepEqual(await gitCommitedFiles(), ['dist/.dotfile']);
 
@@ -198,7 +198,7 @@ test.serial('Skip negated pattern if its alone in its group', async t => {
 
   await outputFile('file.js', 'Test content');
 
-  await publish(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
+  await prepare(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
 
   t.deepEqual(await gitCommitedFiles(), ['file.js']);
 
@@ -210,12 +210,12 @@ test.serial('Skip commit if there is no files to commit', async t => {
   const lastRelease = {};
   const nextRelease = {version: '2.0.0', gitTag: 'v2.0.0', notes: 'Test release note'};
 
-  await publish(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
+  await prepare(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
 
   // Verify the files that have been commited
   t.deepEqual(await gitCommitedFiles(), []);
   t.deepEqual(t.context.log.args[0], ['Creating tag %s', nextRelease.gitTag]);
-  t.deepEqual(t.context.log.args[1], ['Published Git release: %s', nextRelease.gitTag]);
+  t.deepEqual(t.context.log.args[1], ['Prepared Git release: %s', nextRelease.gitTag]);
 });
 
 test.serial('Skip commit if all the modified files are in .gitignore', async t => {
@@ -226,10 +226,10 @@ test.serial('Skip commit if all the modified files are in .gitignore', async t =
   await outputFile('dist/files1.js', 'Test content');
   await outputFile('.gitignore', 'dist/**/*');
 
-  await publish(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
+  await prepare(pluginConfig, {options: t.context.options, lastRelease, nextRelease, logger: t.context.logger});
 
   // Verify the files that have been commited
   t.deepEqual(await gitCommitedFiles(), []);
   t.deepEqual(t.context.log.args[0], ['Creating tag %s', nextRelease.gitTag]);
-  t.deepEqual(t.context.log.args[1], ['Published Git release: %s', nextRelease.gitTag]);
+  t.deepEqual(t.context.log.args[1], ['Prepared Git release: %s', nextRelease.gitTag]);
 });


### PR DESCRIPTION
BREAKING CHANGE: The plugin require sementic-release >=15.0.0 and has to be used in the `prepare` step rather than in `publish`.