### PR TITLE
feat: set name/email of commit author and committer via Git env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ Create a release commit, including configurable files.
 
 ## Configuration
 
-### Environment variables
+## Environment variables
 
-| Variable          | Description                                                                                                                                 | Default                                             |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| `GIT_USERNAME`    | [Git username](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup#_your_identity) associated with the release commit.      | @semantic-release-bot.                              |
-| `GIT_EMAIL`       | [Git email address](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup#_your_identity) associated with the release commit. | @semantic-release-bot email address.                |
+| Variable              | Description                                                                                                                                                              | Default                              |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| `GIT_AUTHOR_NAME`     | The author name associated with the release commit. See [Git environment variables](https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_committing).     | @semantic-release-bot.               |
+| `GIT_AUTHOR_EMAIL`    | The author email associated with the release commit. See [Git environment variables](https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_committing).    | @semantic-release-bot email address. |
+| `GIT_COMMITTER_NAME`  | The committer name associated with the release commit. See [Git environment variables](https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_committing).  | @semantic-release-bot.               |
+| `GIT_COMMITTER_EMAIL` | The committer email associated with the release commit. See [Git environment variables](https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_committing). | @semantic-release-bot email address. |
 
 ### Options
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -25,16 +25,6 @@ async function add(files) {
 }
 
 /**
- * Set Git configuration.
- *
- * @param {String} name Config name.
- * @param {String} value Config value.
- */
-async function config(name, value) {
-  await execa('git', ['config', name, value]);
-}
-
-/**
  * Commit to the local repository.
  *
  * @param {String} message Commit message.
@@ -62,4 +52,4 @@ async function gitHead() {
   return execa.stdout('git', ['rev-parse', 'HEAD']);
 }
 
-module.exports = {getModifiedFiles, add, config, gitHead, commit, push};
+module.exports = {getModifiedFiles, add, gitHead, commit, push};

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -5,7 +5,7 @@ const dirGlob = require('dir-glob');
 const pReduce = require('p-reduce');
 const debug = require('debug')('semantic-release:git');
 const resolveConfig = require('./resolve-config');
-const {getModifiedFiles, add, config, commit, push} = require('./git');
+const {getModifiedFiles, add, commit, push} = require('./git');
 
 const CHANGELOG = 'CHANGELOG.md';
 const PKG_JSON = 'package.json';
@@ -18,8 +18,6 @@ const SKW_JSON = 'npm-shrinkwrap.json';
  * @param {Object} pluginConfig The plugin configuration.
  * @param {String|Array<String>} [pluginConfig.assets] Files to include in the release commit. Can be files path or globs.
  * @param {String} [pluginConfig.message] The message for the release commit.
- * @param {String} [pluginConfig.gitUserName] The username to use for commiting (git `user.name` config).
- * @param {String} [pluginConfig.gitUserEmail] The email to use for commiting (git `user.email` config).
  * @param {Object} context semantic-release context.
  * @param {Object} context.options `semantic-release` configuration.
  * @param {Object} context.lastRelease The last release.
@@ -27,7 +25,7 @@ const SKW_JSON = 'npm-shrinkwrap.json';
  * @param {Object} logger Global logger.
  */
 module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, lastRelease, nextRelease, logger}) => {
-  const {gitUserEmail, gitUserName, message, assets} = resolveConfig(pluginConfig);
+  const {message, assets} = resolveConfig(pluginConfig, logger);
   const patterns = [];
   const modifiedFiles = await getModifiedFiles();
 
@@ -76,8 +74,6 @@ module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, lastRel
   if (filesToCommit.length > 0) {
     logger.log('Found %d file(s) to commit', filesToCommit.length);
     await add(filesToCommit);
-    await config('user.email', gitUserEmail);
-    await config('user.name', gitUserName);
     debug('commited files: %o', filesToCommit);
     await commit(
       message

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,8 +1,3 @@
 const {castArray} = require('lodash');
 
-module.exports = ({message, assets}) => ({
-  gitUserName: process.env.GIT_USERNAME || 'semantic-release-bot',
-  gitUserEmail: process.env.GIT_EMAIL || 'semantic-release-bot@martynus.net',
-  message,
-  assets: assets ? castArray(assets) : assets,
-});
+module.exports = ({message, assets}) => ({message, assets: assets ? castArray(assets) : assets});

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "all": true
   },
   "peerDependencies": {
-    "semantic-release": ">=15.0.0 <16.0.0"
+    "semantic-release": ">=15.4.0 <16.0.0"
   },
   "prettier": {
     "printWidth": 120,

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import {outputFile, appendFile} from 'fs-extra';
-import {add, getModifiedFiles, config, commit, gitHead, push} from '../lib/git';
-import {gitRepo, gitCommits, gitGetCommits, gitGetConfig, gitStaged, gitRemoteHead} from './helpers/git-utils';
+import {add, getModifiedFiles, commit, gitHead, push} from '../lib/git';
+import {gitRepo, gitCommits, gitGetCommits, gitStaged, gitRemoteHead} from './helpers/git-utils';
 
 // Save the current working diretory
 const cwd = process.cwd();
@@ -48,15 +48,6 @@ test.serial('Returns [] if there is no modified files', async t => {
   await gitRepo();
 
   await t.deepEqual(await getModifiedFiles(), []);
-});
-
-test.serial('Set git config', async t => {
-  // Create a git repository, set the current working directory at the root of the repo
-  await gitRepo();
-  // Add config
-  await config('user.name', 'username');
-
-  await t.is(await gitGetConfig('user.name'), 'username');
 });
 
 test.serial('Commit added files', async t => {

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -111,17 +111,6 @@ export async function gitShallowClone(origin, branch = 'master', depth = 1) {
 }
 
 /**
- * Get Git configuration.
- *
- * @param {String} name Config name.
- *
- * @returns {String} The config's value.
- */
-export async function gitGetConfig(name) {
-  return execa.stdout('git', ['config', '--get', name]);
-}
-
-/**
  * @return {Array<String>} Array of staged files path.
  */
 export async function gitStaged() {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -23,8 +23,10 @@ test.beforeEach(t => {
   delete process.env.GH_TOKEN;
   delete process.env.GITHUB_TOKEN;
   delete process.env.GIT_CREDENTIALS;
-  delete process.env.GIT_EMAIL;
-  delete process.env.GIT_USERNAME;
+  delete process.env.GIT_AUTHOR_NAME;
+  delete process.env.GIT_AUTHOR_EMAIL;
+  delete process.env.GIT_COMMITTER_NAME;
+  delete process.env.GIT_COMMITTER_EMAIL;
   // Clear npm cache to refresh the module state
   clearModule('..');
   t.context.m = require('..');
@@ -41,8 +43,6 @@ test.afterEach.always(() => {
 });
 
 test.serial('Prepare from a shallow clone', async t => {
-  process.env.GIT_EMAIL = 'user@email.com';
-  process.env.GIT_USERNAME = 'user';
   const branch = 'master';
   const repositoryUrl = await gitRepo(true);
   await outputFile('package.json', "{name: 'test-package', version: '1.0.0'}");
@@ -69,8 +69,6 @@ test.serial('Prepare from a shallow clone', async t => {
   t.is(commit.subject, `Release version ${nextRelease.version} from branch ${branch}`);
   t.is(commit.body, `${nextRelease.notes}\n`);
   t.is(commit.gitTags, `(HEAD -> ${branch})`);
-  t.is(commit.author.name, process.env.GIT_USERNAME);
-  t.is(commit.author.email, process.env.GIT_EMAIL);
 });
 
 test.serial('Prepare from a detached head repository', async t => {

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -13,8 +13,10 @@ test.beforeEach(t => {
   delete process.env.GH_TOKEN;
   delete process.env.git_TOKEN;
   delete process.env.GIT_CREDENTIALS;
-  delete process.env.GIT_EMAIL;
-  delete process.env.GIT_USERNAME;
+  delete process.env.GIT_AUTHOR_NAME;
+  delete process.env.GIT_AUTHOR_EMAIL;
+  delete process.env.GIT_COMMITTER_NAME;
+  delete process.env.GIT_COMMITTER_EMAIL;
   // Stub the logger functions
   t.context.log = stub();
   t.context.logger = {log: t.context.log};


### PR DESCRIPTION
BREAKING CHANGE: the `GIT_USERNAME` and `GIT_EMAIL` environment variables are replaced by the [Git environment variables](https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_committing) `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME` and `GIT_COMMITTER_EMAIL`.

Fix #37
See semantic-release/semantic-release#784