### PR TITLE
test: sort files array before comparing to expectation

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -64,7 +64,7 @@ test.serial('Prepare from a shallow clone', async t => {
   };
   await t.context.m.prepare(pluginConfig, {logger: t.context.logger, options: {repositoryUrl, branch}, nextRelease});
 
-  t.deepEqual(await gitCommitedFiles(), ['dist/file.js', 'package.json']);
+  t.deepEqual((await gitCommitedFiles()).sort(), ['dist/file.js', 'package.json'].sort());
   const [commit] = await gitGetCommits();
   t.is(commit.subject, `Release version ${nextRelease.version} from branch ${branch}`);
   t.is(commit.body, `${nextRelease.notes}\n`);
@@ -93,7 +93,7 @@ test.serial('Prepare from a detached head repository', async t => {
   };
   await t.context.m.prepare(pluginConfig, {logger: t.context.logger, options: {repositoryUrl, branch}, nextRelease});
 
-  t.deepEqual(await gitCommitedFiles(), ['dist/file.js', 'package.json']);
+  t.deepEqual((await gitCommitedFiles()).sort(), ['dist/file.js', 'package.json'].sort());
   const [commit] = await gitGetCommits();
   t.is(commit.subject, `Release version ${nextRelease.version} from branch ${branch}`);
   t.is(commit.body, `${nextRelease.notes}\n`);

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -47,7 +47,10 @@ test.serial(
     // Verify the remote repo has a the version referencing the same commit sha at the local head
     const [commit] = await gitGetCommits();
     // Verify the files that have been commited
-    t.deepEqual(await gitCommitedFiles(), ['CHANGELOG.md', 'npm-shrinkwrap.json', 'package-lock.json', 'package.json']);
+    t.deepEqual(
+      (await gitCommitedFiles()).sort(),
+      ['CHANGELOG.md', 'npm-shrinkwrap.json', 'package-lock.json', 'package.json'].sort()
+    );
 
     t.is(commit.subject, `chore(release): ${nextRelease.version} [skip ci]`);
     t.is(commit.body, `${nextRelease.notes}\n`);


### PR DESCRIPTION
Improves test stability as under certain circumstances the order of files returned by `git diff-tree` might differ.