### PR TITLE
feat: use `cwd` and `env` options passed by core

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -4,10 +4,12 @@ const debug = require('debug')('semantic-release:git');
 /**
  * Retrieve the list of files modified on the local repository.
  *
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ *
  * @return {Array<String>} Array of modified files path.
  */
-async function getModifiedFiles() {
-  return (await execa.stdout('git', ['ls-files', '-m', '-o']))
+async function getModifiedFiles(execaOpts) {
+  return (await execa.stdout('git', ['ls-files', '-m', '-o'], execaOpts))
     .split('\n')
     .map(tag => tag.trim())
     .filter(tag => Boolean(tag));
@@ -16,10 +18,11 @@ async function getModifiedFiles() {
 /**
  * Add a list of file to the Git index. `.gitignore` will be ignored.
  *
- * @param {Array<String>} files Array of files path to add to the index,
+ * @param {Array<String>} files Array of files path to add to the index.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
  */
-async function add(files) {
-  const shell = await execa('git', ['add', '--force', '--ignore-errors'].concat(files), {reject: false});
+async function add(files, execaOpts) {
+  const shell = await execa('git', ['add', '--force', '--ignore-errors'].concat(files), {...execaOpts, reject: false});
   debug('add file to git index', shell);
 }
 
@@ -27,10 +30,12 @@ async function add(files) {
  * Commit to the local repository.
  *
  * @param {String} message Commit message.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ *
  * @throws {Error} if the commit failed.
  */
-async function commit(message) {
-  await execa('git', ['commit', '-m', message]);
+async function commit(message, execaOpts) {
+  await execa('git', ['commit', '-m', message], execaOpts);
 }
 
 /**
@@ -38,17 +43,23 @@ async function commit(message) {
  *
  * @param {String} origin The remote repository URL.
  * @param {String} branch The branch to push.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ *
  * @throws {Error} if the push failed.
  */
-async function push(origin, branch) {
-  await execa('git', ['push', '--tags', origin, `HEAD:${branch}`]);
+async function push(origin, branch, execaOpts) {
+  await execa('git', ['push', '--tags', origin, `HEAD:${branch}`], execaOpts);
 }
 
 /**
+ * Get the HEAD sha.
+ *
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ *
  * @return {String} The sha of the head commit on the local repository
  */
-async function gitHead() {
-  return execa.stdout('git', ['rev-parse', 'HEAD']);
+async function gitHead(execaOpts) {
+  return execa.stdout('git', ['rev-parse', 'HEAD'], execaOpts);
 }
 
 module.exports = {getModifiedFiles, add, gitHead, commit, push};

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const {pathExists} = require('fs-extra');
 const {isUndefined, isPlainObject, isArray, template, castArray, uniq} = require('lodash');
 const micromatch = require('micromatch');
@@ -8,9 +9,15 @@ const resolveConfig = require('./resolve-config');
 const {getModifiedFiles, add, commit, push} = require('./git');
 
 const CHANGELOG = 'CHANGELOG.md';
-const PKG_JSON = 'package.json';
-const PKG_LOCK = 'package-lock.json';
-const SKW_JSON = 'npm-shrinkwrap.json';
+const PACKAGE_JSON = 'package.json';
+const PACKAGE_LOCK_JSON = 'package-lock.json';
+const SHRINKWRAP_JSON = 'npm-shrinkwrap.json';
+
+// TODO Temporary workaround for https://github.com/kevva/dir-glob/issues/7
+const resolvePaths = (files, cwd) =>
+  files.map(
+    file => `${file.startsWith('!') ? '!' : ''}${path.resolve(cwd, file.startsWith('!') ? file.slice(1) : file)}`
+  );
 
 /**
  * Prepare a release commit including configurable files.
@@ -24,26 +31,33 @@ const SKW_JSON = 'npm-shrinkwrap.json';
  * @param {Object} context.nextRelease The next release.
  * @param {Object} logger Global logger.
  */
-module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, lastRelease, nextRelease, logger}) => {
+module.exports = async (
+  pluginConfig,
+  {env, cwd, options: {branch, repositoryUrl}, lastRelease, nextRelease, logger}
+) => {
   const {message, assets} = resolveConfig(pluginConfig, logger);
   const patterns = [];
-  const modifiedFiles = await getModifiedFiles();
+  const modifiedFiles = await getModifiedFiles({env, cwd});
+  const changelogPath = path.resolve(cwd, CHANGELOG);
+  const pkgPath = path.resolve(cwd, PACKAGE_JSON);
+  const pkgLockPath = path.resolve(cwd, PACKAGE_LOCK_JSON);
+  const shrinkwrapPath = path.resolve(cwd, SHRINKWRAP_JSON);
 
-  if (isUndefined(assets) && (await pathExists(CHANGELOG))) {
-    logger.log('Add %s to the release commit', CHANGELOG);
-    patterns.push(CHANGELOG);
+  if (isUndefined(assets) && (await pathExists(changelogPath))) {
+    logger.log('Add %s to the release commit', changelogPath);
+    patterns.push(changelogPath);
   }
-  if (isUndefined(assets) && (await pathExists(PKG_JSON))) {
-    logger.log('Add %s to the release commit', PKG_JSON);
-    patterns.push(PKG_JSON);
+  if (isUndefined(assets) && (await pathExists(pkgPath))) {
+    logger.log('Add %s to the release commit', pkgPath);
+    patterns.push(pkgPath);
   }
-  if (isUndefined(assets) && (await pathExists(PKG_LOCK))) {
-    logger.log('Add %s to the release commit', PKG_LOCK);
-    patterns.push(PKG_LOCK);
+  if (isUndefined(assets) && (await pathExists(pkgLockPath))) {
+    logger.log('Add %s to the release commit', pkgLockPath);
+    patterns.push(pkgLockPath);
   }
-  if (isUndefined(assets) && (await pathExists(SKW_JSON))) {
-    logger.log('Add %s to the release commit', SKW_JSON);
-    patterns.push(SKW_JSON);
+  if (isUndefined(assets) && (await pathExists(shrinkwrapPath))) {
+    logger.log('Add %s to the release commit', shrinkwrapPath);
+    patterns.push(shrinkwrapPath);
   }
 
   patterns.push(
@@ -64,7 +78,9 @@ module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, lastRel
             glob[0]
           );
         }
-        result.push(...micromatch(modifiedFiles, await dirGlob(glob), {dot: true, nonegate}));
+        result.push(
+          ...micromatch(resolvePaths(modifiedFiles, cwd), await dirGlob(resolvePaths(glob, cwd)), {dot: true, nonegate})
+        );
         return result;
       },
       []
@@ -73,16 +89,17 @@ module.exports = async (pluginConfig, {options: {branch, repositoryUrl}, lastRel
 
   if (filesToCommit.length > 0) {
     logger.log('Found %d file(s) to commit', filesToCommit.length);
-    await add(filesToCommit);
+    await add(filesToCommit, {env, cwd});
     debug('commited files: %o', filesToCommit);
     await commit(
       message
         ? template(message)({branch, lastRelease, nextRelease})
-        : `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`
+        : `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`,
+      {env, cwd}
     );
   }
 
   logger.log('Creating tag %s', nextRelease.gitTag);
-  await push(repositoryUrl, branch);
+  await push(repositoryUrl, branch, {env, cwd});
   logger.log('Prepared Git release: %s', nextRelease.gitTag);
 };

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -1,92 +1,88 @@
+import path from 'path';
 import test from 'ava';
 import {outputFile, appendFile} from 'fs-extra';
 import {add, getModifiedFiles, commit, gitHead, push} from '../lib/git';
 import {gitRepo, gitCommits, gitGetCommits, gitStaged, gitRemoteHead} from './helpers/git-utils';
 
-// Save the current working diretory
-const cwd = process.cwd();
-
-test.afterEach.always(() => {
-  // Restore the current working directory
-  process.chdir(cwd);
-});
-
-test.serial('Add file to index', async t => {
+test('Add file to index', async t => {
   // Create a git repository, set the current working directory at the root of the repo
-  await gitRepo();
+  const {cwd} = await gitRepo();
   // Create files
-  await outputFile('file1.js', '');
+  await outputFile(path.resolve(cwd, 'file1.js'), '');
   // Add files and commit
-  await add(['.']);
+  await add(['.'], {cwd});
 
-  await t.deepEqual(await gitStaged(), ['file1.js']);
+  await t.deepEqual(await gitStaged({cwd}), ['file1.js']);
 });
 
-test.serial('Get the modified files, including files in .gitignore but including untracked ones', async t => {
+test('Get the modified files, including files in .gitignore but including untracked ones', async t => {
   // Create a git repository, set the current working directory at the root of the repo
-  await gitRepo();
+  const {cwd} = await gitRepo();
   // Create files
-  await outputFile('file1.js', '');
-  await outputFile('dir/file2.js', '');
-  await outputFile('file3.js', '');
+  await outputFile(path.resolve(cwd, 'file1.js'), '');
+  await outputFile(path.resolve(cwd, 'dir/file2.js'), '');
+  await outputFile(path.resolve(cwd, 'file3.js'), '');
   // Create .gitignore to ignore file3.js
-  await outputFile('.gitignore', 'file.3.js');
+  await outputFile(path.resolve(cwd, '.gitignore'), 'file.3.js');
   // Add files and commit
-  await add(['.']);
-  await commit('Test commit');
+  await add(['.'], {cwd});
+  await commit('Test commit', {cwd});
   // Update file1.js, dir/file2.js and file3.js
-  await appendFile('file1.js', 'Test content');
-  await appendFile('dir/file2.js', 'Test content');
-  await appendFile('file3.js', 'Test content');
+  await appendFile(path.resolve(cwd, 'file1.js'), 'Test content');
+  await appendFile(path.resolve(cwd, 'dir/file2.js'), 'Test content');
+  await appendFile(path.resolve(cwd, 'file3.js'), 'Test content');
   // Add untracked file
-  await outputFile('file4.js', 'Test content');
+  await outputFile(path.resolve(cwd, 'file4.js'), 'Test content');
 
-  await t.deepEqual((await getModifiedFiles()).sort(), ['file4.js', 'file3.js', 'dir/file2.js', 'file1.js'].sort());
+  await t.deepEqual(
+    (await getModifiedFiles({cwd})).sort(),
+    ['file4.js', 'file3.js', 'dir/file2.js', 'file1.js'].sort()
+  );
 });
 
-test.serial('Returns [] if there is no modified files', async t => {
+test('Returns [] if there is no modified files', async t => {
   // Create a git repository, set the current working directory at the root of the repo
-  await gitRepo();
+  const {cwd} = await gitRepo();
 
-  await t.deepEqual(await getModifiedFiles(), []);
+  await t.deepEqual(await getModifiedFiles({cwd}), []);
 });
 
-test.serial('Commit added files', async t => {
+test('Commit added files', async t => {
   // Create a git repository, set the current working directory at the root of the repo
-  await gitRepo();
+  const {cwd} = await gitRepo();
   // Create files
-  await outputFile('file1.js', '');
+  await outputFile(path.resolve(cwd, 'file1.js'), '');
   // Add files and commit
-  await add(['.']);
-  await commit('Test commit');
+  await add(['.'], {cwd});
+  await commit('Test commit', {cwd});
 
-  await t.true((await gitGetCommits()).length === 1);
+  await t.true((await gitGetCommits(undefined, {cwd})).length === 1);
 });
 
-test.serial('Get the last commit sha', async t => {
+test('Get the last commit sha', async t => {
   // Create a git repository, set the current working directory at the root of the repo
-  await gitRepo();
+  const {cwd} = await gitRepo();
   // Add commits to the master branch
-  const [{hash}] = await gitCommits(['First']);
+  const [{hash}] = await gitCommits(['First'], {cwd});
 
-  const result = await gitHead();
+  const result = await gitHead({cwd});
 
   t.is(result, hash);
 });
 
-test.serial('Throw error if the last commit sha cannot be found', async t => {
+test('Throw error if the last commit sha cannot be found', async t => {
   // Create a git repository, set the current working directory at the root of the repo
-  await gitRepo();
+  const {cwd} = await gitRepo();
 
-  await t.throws(gitHead());
+  await t.throws(gitHead({cwd}));
 });
 
-test.serial('Push commit to remote repository', async t => {
+test('Push commit to remote repository', async t => {
   // Create a git repository with a remote, set the current working directory at the root of the repo
-  const repo = await gitRepo(true);
-  const [{hash}] = await gitCommits(['Test commit']);
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  const [{hash}] = await gitCommits(['Test commit'], {cwd});
 
-  await push(repo, 'master');
+  await push(repositoryUrl, 'master', {cwd});
 
-  t.is(await gitRemoteHead(repo), hash);
+  t.is(await gitRemoteHead(repositoryUrl), hash, {cwd});
 });

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -1,37 +1,9 @@
 import test from 'ava';
-import {stub} from 'sinon';
 import verify from '../lib/verify';
-import {gitRepo, gitCommits} from './helpers/git-utils';
-
-// Save the current process.env
-const envBackup = Object.assign({}, process.env);
-// Save the current working diretory
-const cwd = process.cwd();
-
-test.beforeEach(t => {
-  // Delete env paramaters that could have been set on the machine running the tests
-  delete process.env.GH_TOKEN;
-  delete process.env.git_TOKEN;
-  delete process.env.GIT_CREDENTIALS;
-  delete process.env.GIT_AUTHOR_NAME;
-  delete process.env.GIT_AUTHOR_EMAIL;
-  delete process.env.GIT_COMMITTER_NAME;
-  delete process.env.GIT_COMMITTER_EMAIL;
-  // Stub the logger functions
-  t.context.log = stub();
-  t.context.logger = {log: t.context.log};
-});
-
-test.afterEach.always(() => {
-  // Restore process.env
-  process.env = envBackup;
-  // Restore the current working directory
-  process.chdir(cwd);
-});
 
 test('Throw SemanticReleaseError if "assets" option is not a String or false or an Array of Objects', async t => {
   const assets = true;
-  const [error] = await t.throws(verify({assets}, {}, t.context.logger));
+  const [error] = await t.throws(verify({assets}));
 
   t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'EINVALIDASSETS');
@@ -39,78 +11,57 @@ test('Throw SemanticReleaseError if "assets" option is not a String or false or 
 
 test('Throw SemanticReleaseError if "assets" option is not an Array with invalid elements', async t => {
   const assets = ['file.js', 42];
-  const [error] = await t.throws(verify({assets}, {}, t.context.logger));
+  const [error] = await t.throws(verify({assets}));
 
   t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'EINVALIDASSETS');
 });
 
-test.serial('Verify "assets" is a String', async t => {
-  // Create a git repository with a remote, set the current working directory at the root of the repo
-  const repo = await gitRepo(true);
-  await gitCommits(['Test commit']);
+test('Verify "assets" is a String', async t => {
   const assets = 'file2.js';
 
-  await t.notThrows(verify({assets}, {repositoryUrl: repo, branch: 'master'}, t.context.logger));
+  await t.notThrows(verify({assets}));
 });
 
-test.serial('Verify "assets" is an Array of String', async t => {
-  // Create a git repository with a remote, set the current working directory at the root of the repo
-  const repo = await gitRepo(true);
-  await gitCommits(['Test commit']);
+test('Verify "assets" is an Array of String', async t => {
   const assets = ['file1.js', 'file2.js'];
 
-  await t.notThrows(verify({assets}, {repositoryUrl: repo, branch: 'master'}, t.context.logger));
+  await t.notThrows(verify({assets}));
 });
 
-test.serial('Verify "assets" is an Object with a path property', async t => {
-  // Create a git repository with a remote, set the current working directory at the root of the repo
-  const repo = await gitRepo(true);
-  await gitCommits(['Test commit']);
+test('Verify "assets" is an Object with a path property', async t => {
   const assets = {path: 'file2.js'};
 
-  await t.notThrows(verify({assets}, {repositoryUrl: repo, branch: 'master'}, t.context.logger));
+  await t.notThrows(verify({assets}));
 });
 
-test.serial('Verify "assets" is an Array of Object with a path property', async t => {
-  // Create a git repository with a remote, set the current working directory at the root of the repo
-  const repo = await gitRepo(true);
-  await gitCommits(['Test commit']);
+test('Verify "assets" is an Array of Object with a path property', async t => {
   const assets = [{path: 'file1.js'}, {path: 'file2.js'}];
 
-  await t.notThrows(verify({assets}, {repositoryUrl: repo, branch: 'master'}, t.context.logger));
+  await t.notThrows(verify({assets}));
 });
 
-test.serial('Verify disabled "assets" (set to false)', async t => {
-  // Create a git repository with a remote, set the current working directory at the root of the repo
-  const repo = await gitRepo(true);
-  await gitCommits(['Test commit']);
+test('Verify disabled "assets" (set to false)', async t => {
   const assets = false;
 
-  await t.notThrows(verify({assets}, {repositoryUrl: repo, branch: 'master'}, t.context.logger));
+  await t.notThrows(verify({assets}));
 });
 
-test.serial('Verify "assets" is an Array of glob Arrays', async t => {
-  // Create a git repository with a remote, set the current working directory at the root of the repo
-  const repo = await gitRepo(true);
-  await gitCommits(['Test commit']);
+test('Verify "assets" is an Array of glob Arrays', async t => {
   const assets = [['dist/**', '!**/*.js'], 'file2.js'];
 
-  await t.notThrows(verify({assets}, {repositoryUrl: repo, branch: 'master'}, t.context.logger));
+  await t.notThrows(verify({assets}));
 });
 
-test.serial('Verify "assets" is an Array of Object with a glob Arrays in path property', async t => {
-  // Create a git repository with a remote, set the current working directory at the root of the repo
-  const repo = await gitRepo(true);
-  await gitCommits(['Test commit']);
+test('Verify "assets" is an Array of Object with a glob Arrays in path property', async t => {
   const assets = [{path: ['dist/**', '!**/*.js']}, {path: 'file2.js'}];
 
-  await t.notThrows(verify({assets}, {repositoryUrl: repo, branch: 'master'}, t.context.logger));
+  await t.notThrows(verify({assets}));
 });
 
 test('Throw SemanticReleaseError if "message" option is not a String', async t => {
   const message = 42;
-  const [error] = await t.throws(verify({message}, {}, t.context.logger));
+  const [error] = await t.throws(verify({message}));
 
   t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'EINVALIDMESSAGE');
@@ -118,7 +69,7 @@ test('Throw SemanticReleaseError if "message" option is not a String', async t =
 
 test('Throw SemanticReleaseError if "message" option is an empty String', async t => {
   const message = '';
-  const [error] = await t.throws(verify({message}, {}, t.context.logger));
+  const [error] = await t.throws(verify({message}));
 
   t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'EINVALIDMESSAGE');
@@ -126,16 +77,12 @@ test('Throw SemanticReleaseError if "message" option is an empty String', async 
 
 test('Throw SemanticReleaseError if "message" option is a whitespace String', async t => {
   const message = '  \n \r ';
-  const [error] = await t.throws(verify({message}, {}, t.context.logger));
+  const [error] = await t.throws(verify({message}));
 
   t.is(error.name, 'SemanticReleaseError');
   t.is(error.code, 'EINVALIDMESSAGE');
 });
 
-test.serial('Verify undefined "message" and "assets"', async t => {
-  // Create a git repository with a remote, set the current working directory at the root of the repo
-  const repo = await gitRepo(true);
-  await gitCommits(['Test commit']);
-
-  await t.notThrows(verify({}, {repositoryUrl: repo, branch: 'master'}, t.context.logger));
+test('Verify undefined "message" and "assets"', async t => {
+  await t.notThrows(verify({}));
 });


### PR DESCRIPTION
BREAKING CHANGE: require `semantic-release` >= `15.8.0`