### PR TITLE
fix: glob `assets` before running `git ls-files`

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -2,17 +2,18 @@ const execa = require('execa');
 const debug = require('debug')('semantic-release:git');
 
 /**
- * Retrieve the list of files modified on the local repository.
+ * Filter files modified on the local repository.
  *
+ * @param {Array<String>} files List of file paths to filter.
  * @param {Object} [execaOpts] Options to pass to `execa`.
  *
  * @return {Array<String>} Array of modified files path.
  */
-async function getModifiedFiles(execaOpts) {
-  return (await execa.stdout('git', ['ls-files', '-m', '-o'], execaOpts))
+async function filterModifiedFiles(files, execaOpts) {
+  return (await execa.stdout('git', ['ls-files', '-m', '-o', ...files], execaOpts))
     .split('\n')
-    .map(tag => tag.trim())
-    .filter(tag => Boolean(tag));
+    .map(file => file.trim())
+    .filter(file => Boolean(file));
 }
 
 /**
@@ -22,7 +23,7 @@ async function getModifiedFiles(execaOpts) {
  * @param {Object} [execaOpts] Options to pass to `execa`.
  */
 async function add(files, execaOpts) {
-  const shell = await execa('git', ['add', '--force', '--ignore-errors'].concat(files), {...execaOpts, reject: false});
+  const shell = await execa('git', ['add', '--force', '--ignore-errors', ...files], {...execaOpts, reject: false});
   debug('add file to git index', shell);
 }
 
@@ -62,4 +63,4 @@ async function gitHead(execaOpts) {
   return execa.stdout('git', ['rev-parse', 'HEAD'], execaOpts);
 }
 
-module.exports = {getModifiedFiles, add, gitHead, commit, push};
+module.exports = {filterModifiedFiles, add, gitHead, commit, push};

--- a/lib/glob-assets.js
+++ b/lib/glob-assets.js
@@ -1,0 +1,44 @@
+const path = require('path');
+const {isPlainObject, castArray, uniq} = require('lodash');
+const dirGlob = require('dir-glob');
+const globby = require('globby');
+const debug = require('debug')('semantic-release:github');
+
+const filesTransform = (files, cwd, transform) =>
+  files.map(file => `${file.startsWith('!') ? '!' : ''}${transform(cwd, file.startsWith('!') ? file.slice(1) : file)}`);
+
+module.exports = async ({cwd}, assets) =>
+  uniq(
+    [].concat(
+      ...(await Promise.all(
+        assets.map(async asset => {
+          // Wrap single glob definition in Array
+          let glob = castArray(isPlainObject(asset) ? asset.path : asset);
+          // TODO Temporary workaround for https://github.com/kevva/dir-glob/issues/7 and https://github.com/mrmlnc/fast-glob/issues/47
+          glob = uniq([
+            ...filesTransform(await dirGlob(filesTransform(glob, cwd, path.resolve)), cwd, path.relative),
+            ...glob,
+          ]);
+
+          // Skip solo negated pattern (avoid to include every non js file with `!**/*.js`)
+          if (glob.length <= 1 && glob[0].startsWith('!')) {
+            debug(
+              'skipping the negated glob %o as its alone in its group and would retrieve a large amount of files',
+              glob[0]
+            );
+            return [];
+          }
+
+          const globbed = await globby(glob, {
+            cwd,
+            expandDirectories: true,
+            gitignore: false,
+            dot: true,
+            onlyFiles: false,
+          });
+
+          return globbed.length > 0 ? globbed : [];
+        })
+      ))
+    )
+  );

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -1,23 +1,8 @@
-const path = require('path');
-const {pathExists} = require('fs-extra');
-const {isUndefined, isPlainObject, isArray, template, castArray, uniq} = require('lodash');
-const micromatch = require('micromatch');
-const dirGlob = require('dir-glob');
-const pReduce = require('p-reduce');
+const {template} = require('lodash');
 const debug = require('debug')('semantic-release:git');
 const resolveConfig = require('./resolve-config');
-const {getModifiedFiles, add, commit, push} = require('./git');
-
-const CHANGELOG = 'CHANGELOG.md';
-const PACKAGE_JSON = 'package.json';
-const PACKAGE_LOCK_JSON = 'package-lock.json';
-const SHRINKWRAP_JSON = 'npm-shrinkwrap.json';
-
-// TODO Temporary workaround for https://github.com/kevva/dir-glob/issues/7
-const resolvePaths = (files, cwd) =>
-  files.map(
-    file => `${file.startsWith('!') ? '!' : ''}${path.resolve(cwd, file.startsWith('!') ? file.slice(1) : file)}`
-  );
+const globAssets = require('./glob-assets.js');
+const {filterModifiedFiles, add, commit, push} = require('./git');
 
 /**
  * Prepare a release commit including configurable files.
@@ -31,75 +16,36 @@ const resolvePaths = (files, cwd) =>
  * @param {Object} context.nextRelease The next release.
  * @param {Object} logger Global logger.
  */
-module.exports = async (
-  pluginConfig,
-  {env, cwd, options: {branch, repositoryUrl}, lastRelease, nextRelease, logger}
-) => {
+module.exports = async (pluginConfig, context) => {
+  const {
+    env,
+    cwd,
+    options: {branch, repositoryUrl},
+    lastRelease,
+    nextRelease,
+    logger,
+  } = context;
   const {message, assets} = resolveConfig(pluginConfig, logger);
-  const patterns = [];
-  const modifiedFiles = await getModifiedFiles({env, cwd});
-  const changelogPath = path.resolve(cwd, CHANGELOG);
-  const pkgPath = path.resolve(cwd, PACKAGE_JSON);
-  const pkgLockPath = path.resolve(cwd, PACKAGE_LOCK_JSON);
-  const shrinkwrapPath = path.resolve(cwd, SHRINKWRAP_JSON);
 
-  if (isUndefined(assets) && (await pathExists(changelogPath))) {
-    logger.log('Add %s to the release commit', changelogPath);
-    patterns.push(changelogPath);
-  }
-  if (isUndefined(assets) && (await pathExists(pkgPath))) {
-    logger.log('Add %s to the release commit', pkgPath);
-    patterns.push(pkgPath);
-  }
-  if (isUndefined(assets) && (await pathExists(pkgLockPath))) {
-    logger.log('Add %s to the release commit', pkgLockPath);
-    patterns.push(pkgLockPath);
-  }
-  if (isUndefined(assets) && (await pathExists(shrinkwrapPath))) {
-    logger.log('Add %s to the release commit', shrinkwrapPath);
-    patterns.push(shrinkwrapPath);
-  }
+  if (assets && assets.length > 0) {
+    const globbedAssets = await globAssets(context, assets);
+    debug('globed assets: %o', globbedAssets);
 
-  patterns.push(
-    ...(assets || []).map(pattern => (!isArray(pattern) && isPlainObject(pattern) ? pattern.path : pattern))
-  );
+    const filesToCommit = await filterModifiedFiles(globbedAssets, {cwd, env});
 
-  const filesToCommit = uniq(
-    await pReduce(
-      patterns,
-      async (result, pattern) => {
-        const glob = castArray(pattern);
-        let nonegate;
-        // Skip solo negated pattern (avoid to include every non js file with `!**/*.js`)
-        if (glob.length <= 1 && glob[0].startsWith('!')) {
-          nonegate = true;
-          debug(
-            'skipping the negated glob %o as its alone in its group and would retrieve a large amount of files ',
-            glob[0]
-          );
-        }
-        result.push(
-          ...micromatch(resolvePaths(modifiedFiles, cwd), await dirGlob(resolvePaths(glob, cwd)), {dot: true, nonegate})
-        );
-        return result;
-      },
-      []
-    )
-  );
+    if (filesToCommit.length > 0) {
+      logger.log('Found %d file(s) to commit', filesToCommit.length);
+      await add(filesToCommit, {env, cwd});
+      debug('commited files: %o', filesToCommit);
+      await commit(
+        message
+          ? template(message)({branch, lastRelease, nextRelease})
+          : `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`,
+        {env, cwd}
+      );
+    }
 
-  if (filesToCommit.length > 0) {
-    logger.log('Found %d file(s) to commit', filesToCommit.length);
-    await add(filesToCommit, {env, cwd});
-    debug('commited files: %o', filesToCommit);
-    await commit(
-      message
-        ? template(message)({branch, lastRelease, nextRelease})
-        : `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`,
-      {env, cwd}
-    );
+    await push(repositoryUrl, branch, {env, cwd});
+    logger.log('Prepared Git release: %s', nextRelease.gitTag);
   }
-
-  logger.log('Creating tag %s', nextRelease.gitTag);
-  await push(repositoryUrl, branch, {env, cwd});
-  logger.log('Prepared Git release: %s', nextRelease.gitTag);
 };

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,3 +1,10 @@
-const {castArray} = require('lodash');
+const {isUndefined, castArray} = require('lodash');
 
-module.exports = ({assets, message}) => ({assets: assets ? castArray(assets) : assets, message});
+module.exports = ({assets, message}) => ({
+  assets: isUndefined(assets)
+    ? ['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']
+    : assets
+      ? castArray(assets)
+      : assets,
+  message,
+});

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dir-glob": "^2.0.0",
     "execa": "^0.10.0",
     "fs-extra": "^7.0.0",
+    "globby": "^8.0.1",
     "lodash": "^4.17.4",
     "micromatch": "^3.1.4",
     "p-reduce": "^1.0.0"

--- a/test/fixtures/files/.dotfile
+++ b/test/fixtures/files/.dotfile
@@ -1,0 +1,1 @@
+dotfile content

--- a/test/fixtures/files/upload.txt
+++ b/test/fixtures/files/upload.txt
@@ -1,0 +1,1 @@
+Upload file content

--- a/test/fixtures/files/upload_other.txt
+++ b/test/fixtures/files/upload_other.txt
@@ -1,0 +1,1 @@
+Upload_other file content

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import test from 'ava';
 import {outputFile, appendFile} from 'fs-extra';
-import {add, getModifiedFiles, commit, gitHead, push} from '../lib/git';
+import {add, filterModifiedFiles, commit, gitHead, push} from '../lib/git';
 import {gitRepo, gitCommits, gitGetCommits, gitStaged, gitRemoteHead} from './helpers/git-utils';
 
 test('Add file to index', async t => {
@@ -15,7 +15,7 @@ test('Add file to index', async t => {
   await t.deepEqual(await gitStaged({cwd}), ['file1.js']);
 });
 
-test('Get the modified files, including files in .gitignore but including untracked ones', async t => {
+test('Filter modified files, including files in .gitignore and untracked ones', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   const {cwd} = await gitRepo();
   // Create files
@@ -35,8 +35,8 @@ test('Get the modified files, including files in .gitignore but including untrac
   await outputFile(path.resolve(cwd, 'file4.js'), 'Test content');
 
   await t.deepEqual(
-    (await getModifiedFiles({cwd})).sort(),
-    ['file4.js', 'file3.js', 'dir/file2.js', 'file1.js'].sort()
+    (await filterModifiedFiles(['file1.js', 'dir/file2.js', 'file3.js', 'file4.js'], {cwd})).sort(),
+    ['file1.js', 'dir/file2.js', 'file3.js', 'file4.js'].sort()
   );
 });
 
@@ -44,7 +44,7 @@ test('Returns [] if there is no modified files', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   const {cwd} = await gitRepo();
 
-  await t.deepEqual(await getModifiedFiles({cwd}), []);
+  await t.deepEqual(await filterModifiedFiles(['file1.js', 'file2.js'], {cwd}), []);
 });
 
 test('Commit added files', async t => {

--- a/test/glob-assets.test.js
+++ b/test/glob-assets.test.js
@@ -1,0 +1,138 @@
+import path from 'path';
+import test from 'ava';
+import {copy, ensureDir} from 'fs-extra';
+import tempy from 'tempy';
+import globAssets from '../lib/glob-assets';
+
+const fixtures = 'test/fixtures/files';
+
+test('Retrieve file from single path', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  const globbedAssets = await globAssets({cwd}, ['upload.txt']);
+
+  t.deepEqual(globbedAssets, ['upload.txt']);
+});
+
+test('Retrieve multiple files from path', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  const globbedAssets = await globAssets({cwd}, ['upload.txt', 'upload_other.txt']);
+
+  t.deepEqual(globbedAssets.sort(), ['upload_other.txt', 'upload.txt'].sort());
+});
+
+test('Retrieve multiple files from Object', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  const globbedAssets = await globAssets({cwd}, [
+    {path: 'upload.txt', name: 'upload_name', label: 'Upload label'},
+    'upload_other.txt',
+  ]);
+
+  t.deepEqual(globbedAssets.sort(), ['upload.txt', 'upload_other.txt'].sort());
+});
+
+test('Retrieve multiple files without duplicates', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  const globbedAssets = await globAssets({cwd}, [
+    'upload_other.txt',
+    'upload.txt',
+    'upload_other.txt',
+    'upload.txt',
+    'upload.txt',
+    'upload_other.txt',
+  ]);
+
+  t.deepEqual(globbedAssets.sort(), ['upload_other.txt', 'upload.txt'].sort());
+});
+
+test('Retrieve file from single glob', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  const globbedAssets = await globAssets({cwd}, ['upload.*']);
+
+  t.deepEqual(globbedAssets, ['upload.txt']);
+});
+
+test('Retrieve multiple files from single glob', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  const globbedAssets = await globAssets({cwd}, ['*.txt']);
+
+  t.deepEqual(globbedAssets.sort(), ['upload_other.txt', 'upload.txt'].sort());
+});
+
+test('Accept glob array with one value', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  const globbedAssets = await globAssets({cwd}, [['*load.txt'], ['*_other.txt']]);
+
+  t.deepEqual(globbedAssets.sort(), ['upload_other.txt', 'upload.txt'].sort());
+});
+
+test('Exclude globs that resolve to no files', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  const globbedAssets = await globAssets({cwd}, [['upload.txt', '!upload.txt']]);
+
+  t.deepEqual(globbedAssets, []);
+});
+
+test('Accept glob array with one value for missing files', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  const globbedAssets = await globAssets({cwd}, [['*missing.txt'], ['*_other.txt']]);
+
+  t.deepEqual(globbedAssets.sort(), ['upload_other.txt'].sort());
+});
+
+test('Include dotfiles', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  const globbedAssets = await globAssets({cwd}, ['.dot*']);
+
+  t.deepEqual(globbedAssets, ['.dotfile']);
+});
+
+test('Ingnore single negated glob', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  const globbedAssets = await globAssets({cwd}, ['!*.txt']);
+
+  t.deepEqual(globbedAssets, []);
+});
+
+test('Ingnore single negated glob in Object', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  const globbedAssets = await globAssets({cwd}, [{path: '!*.txt'}]);
+
+  t.deepEqual(globbedAssets, []);
+});
+
+test('Accept negated globs', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  const globbedAssets = await globAssets({cwd}, [['*.txt', '!**/*_other.txt']]);
+
+  t.deepEqual(globbedAssets, ['upload.txt']);
+});
+
+test('Expand directories', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, path.resolve(cwd, 'dir'));
+  const globbedAssets = await globAssets({cwd}, [['dir']]);
+
+  t.deepEqual(globbedAssets.sort(), ['dir', 'dir/upload_other.txt', 'dir/upload.txt', 'dir/.dotfile'].sort());
+});
+
+test('Include empty directory as defined', async t => {
+  const cwd = tempy.directory();
+  await copy(fixtures, cwd);
+  await ensureDir(path.resolve(cwd, 'empty'));
+  const globbedAssets = await globAssets({cwd}, [['empty']]);
+
+  t.deepEqual(globbedAssets, ['empty']);
+});

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -40,13 +40,8 @@ test('Commit CHANGELOG.md, package.json, package-lock.json, and npm-shrinkwrap.j
   t.is(commit.subject, `chore(release): ${nextRelease.version} [skip ci]`);
   t.is(commit.body, `${nextRelease.notes}\n`);
   t.is(commit.gitTags, `(HEAD -> ${options.branch})`);
-  t.deepEqual(t.context.log.args[0], ['Add %s to the release commit', changelogPath]);
-  t.deepEqual(t.context.log.args[1], ['Add %s to the release commit', pkgPath]);
-  t.deepEqual(t.context.log.args[2], ['Add %s to the release commit', pkgLockPath]);
-  t.deepEqual(t.context.log.args[3], ['Add %s to the release commit', shrinkwrapPath]);
-  t.deepEqual(t.context.log.args[4], ['Found %d file(s) to commit', 4]);
-  t.deepEqual(t.context.log.args[5], ['Creating tag %s', nextRelease.gitTag]);
-  t.deepEqual(t.context.log.args[6], ['Prepared Git release: %s', nextRelease.gitTag]);
+  t.deepEqual(t.context.log.args[0], ['Found %d file(s) to commit', 4]);
+  t.deepEqual(t.context.log.args[1], ['Prepared Git release: %s', nextRelease.gitTag]);
 });
 
 test('Exclude CHANGELOG.md, package.json, package-lock.json, and npm-shrinkwrap.json if "assets" is defined without it', async t => {
@@ -65,8 +60,6 @@ test('Exclude CHANGELOG.md, package.json, package-lock.json, and npm-shrinkwrap.
 
   // Verify no files have been commited
   t.deepEqual(await gitCommitedFiles('HEAD', {cwd, env}), []);
-  t.deepEqual(t.context.log.args[0], ['Creating tag %s', nextRelease.gitTag]);
-  t.deepEqual(t.context.log.args[1], ['Prepared Git release: %s', nextRelease.gitTag]);
 });
 
 test.serial('Allow to customize the commit message', async t => {
@@ -242,6 +235,4 @@ test('Skip commit if there is no files to commit', async t => {
 
   // Verify the files that have been commited
   t.deepEqual(await gitCommitedFiles('HEAD', {cwd, env}), []);
-  t.deepEqual(t.context.log.args[0], ['Creating tag %s', nextRelease.gitTag]);
-  t.deepEqual(t.context.log.args[1], ['Prepared Git release: %s', nextRelease.gitTag]);
 });


### PR DESCRIPTION
Fix #62 

The command `git ls-files -m -o` seems to behave differently based on the Git version used. In addition it fails on certain Git versions when `.git` or `.gitmodules` are included in the project dependencies.
This change glob the `assets` first, avoiding to run `git ls-files -m -o` on the entire repo.