### PR TITLE
docs: fix typo in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Options can be set within the plugin definition in the Semantic-release configur
       "@semantic-release/npm",
       {
         "path": "@semantic-release/git",
-        "assets": ["package.json", "dist/**/*.{js|css}", "docs"],
+        "assets": ["package.json", "dist/**/*.{js,css}", "docs"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],


### PR DESCRIPTION
Fix #68 