### PR TITLE
feat: optionally execute 'git push' during the publish phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ $RECYCLE.BIN/
 
 package-lock.json
 yarn.lock
+.idea/

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
     "@semantic-release/release-notes-generator",
     ["@semantic-release/git", {
       "assets": ["dist/**/*.{js,css}", "docs", "package.json"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+      "pushStep": "prepare"
     }]
   ]
 }
@@ -64,6 +65,7 @@ When configuring branches permission on a Git hosting service (e.g. [GitHub prot
 |-----------|------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
 | `message` | The message for the release commit. See [message](#message).                                                                 | `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`     |
 | `assets`  | Files to include in the release commit. Set to `false` to disable adding files to the release commit. See [assets](#assets). | `['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']` |
+| `pushStep`| The lifecycle phase at which the created git commit will be pushed to the remote repository.                                 | `prepare`                                                                      |
 
 #### `message`
 
@@ -106,6 +108,10 @@ If a directory is configured, all the files under this directory and its childre
 `[['dist', '!**/*.css'], 'package.json']`: include `package.json` and all files in the `dist` directory and its sub-directories excluding the `css` files.
 
 `[['dist/**/*.{js,css}', '!**/*.min.*']]`: include all `js` and `css` files in the `dist` directory and its sub-directories excluding the minified version.
+
+#### `pushStep`
+
+Can be either `prepare` or `publish`.
 
 ### Examples
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const {defaultTo, castArray} = require('lodash');
 const verifyGit = require('./lib/verify');
 const prepareGit = require('./lib/prepare');
+const publishGit = require('./lib/publish');
 
 let verified;
 
@@ -13,6 +14,7 @@ function verifyConditions(pluginConfig, context) {
 
     pluginConfig.assets = defaultTo(pluginConfig.assets, preparePlugin.assets);
     pluginConfig.message = defaultTo(pluginConfig.message, preparePlugin.message);
+    pluginConfig.pushStep = defaultTo(pluginConfig.pushStep, preparePlugin.pushStep);
   }
 
   verifyGit(pluginConfig);
@@ -28,4 +30,13 @@ async function prepare(pluginConfig, context) {
   await prepareGit(pluginConfig, context);
 }
 
-module.exports = {verifyConditions, prepare};
+async function publish(pluginConfig, context) {
+  if (!verified) {
+    verifyGit(pluginConfig);
+    verified = true;
+  }
+
+  await publishGit(pluginConfig, context);
+}
+
+module.exports = {verifyConditions, prepare, publish};

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -18,4 +18,12 @@ Your configuration for the \`assets\` option is \`${assets}\`.`,
 
 Your configuration for the \`successComment\` option is \`${message}\`.`,
   }),
+  EINVALIDPUSHSTEP: ({pushStep}) => ({
+    message: 'Invalid `pushStep` option.',
+    details: `The [pushStep](${linkify(
+      'README.md#pushStep'
+    )}) option, if defined, must be either \`prepare\` or \`publish\`.
+
+Your configuration for the \`pushStep\` option is \`${pushStep}\`.`,
+  }),
 };

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -10,11 +10,12 @@ const {filterModifiedFiles, add, commit, push} = require('./git');
  * @param {Object} pluginConfig The plugin configuration.
  * @param {String|Array<String>} [pluginConfig.assets] Files to include in the release commit. Can be files path or globs.
  * @param {String} [pluginConfig.message] The message for the release commit.
+ * @param {String} [pluginConfig.pushStep] Step at which commits are pushed to git.
  * @param {Object} context semantic-release context.
  * @param {Object} context.options `semantic-release` configuration.
  * @param {Object} context.lastRelease The last release.
  * @param {Object} context.nextRelease The next release.
- * @param {Object} logger Global logger.
+ * @param {Object} context.logger Global logger.
  */
 module.exports = async (pluginConfig, context) => {
   const {
@@ -25,7 +26,7 @@ module.exports = async (pluginConfig, context) => {
     nextRelease,
     logger,
   } = context;
-  const {message, assets} = resolveConfig(pluginConfig, logger);
+  const {message, assets, pushStep} = resolveConfig(pluginConfig);
 
   if (assets && assets.length > 0) {
     const globbedAssets = await globAssets(context, assets);
@@ -45,7 +46,10 @@ module.exports = async (pluginConfig, context) => {
       );
     }
 
-    await push(repositoryUrl, branch, {env, cwd});
+    if (pushStep === 'prepare') {
+      await push(repositoryUrl, branch, {env, cwd});
+    }
+
     logger.log('Prepared Git release: %s', nextRelease.gitTag);
   }
 };

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -1,0 +1,27 @@
+const resolveConfig = require('./resolve-config');
+const {push} = require('./git');
+
+/**
+ * Publish a release commit including configurable files.
+ *
+ * @param {Object} pluginConfig The plugin configuration.
+ * @param {String} [pluginConfig.pushStep] Step at which commits are pushed to git.
+ * @param {Object} context semantic-release context.
+ * @param {Object} context.options `semantic-release` configuration.
+ * @param {Object} context.nextRelease The next release.
+ * @param {Object} context.logger Global logger.
+ */
+module.exports = async (pluginConfig, context) => {
+  const {
+    env,
+    cwd,
+    options: {branch, repositoryUrl},
+    nextRelease,
+    logger,
+  } = context;
+  const {pushStep} = resolveConfig(pluginConfig);
+  if (pushStep === 'publish') {
+    await push(repositoryUrl, branch, {env, cwd});
+    logger.log('Published Git commit for: %s', nextRelease.gitTag);
+  }
+};

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,10 +1,11 @@
-const {isNil, castArray} = require('lodash');
+const {isNil, castArray, defaultTo} = require('lodash');
 
-module.exports = ({assets, message}) => ({
+module.exports = ({assets, message, pushStep}) => ({
   assets: isNil(assets)
     ? ['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']
     : assets
     ? castArray(assets)
     : assets,
   message,
+  pushStep: defaultTo(pushStep, 'prepare'),
 });

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -7,22 +7,26 @@ const isNonEmptyString = value => isString(value) && value.trim();
 const isStringOrStringArray = value => isNonEmptyString(value) || (isArray(value) && value.every(isNonEmptyString));
 const isArrayOf = validator => array => isArray(array) && array.every(value => validator(value));
 const canBeDisabled = validator => value => value === false || validator(value);
+const validPushStep = value => ['prepare', 'publish'].includes(value);
 
 const VALIDATORS = {
   assets: canBeDisabled(
     isArrayOf(asset => isStringOrStringArray(asset) || (isPlainObject(asset) && isStringOrStringArray(asset.path)))
   ),
   message: isNonEmptyString,
+  pushStep: validPushStep,
 };
 
 /**
  * Verify the commit `message` format and the `assets` option configuration:
  * - The commit `message`, is defined, must a non empty `String`.
  * - The `assets` configuration must be an `Array` of `String` (file path) or `false` (to disable).
+ * - The `pushStep` configuration must be one of 'prepare' or 'publish'.
  *
  * @param {Object} pluginConfig The plugin configuration.
  * @param {String|Array<String|Object>} [pluginConfig.assets] Files to include in the release commit. Can be files path or globs.
  * @param {String} [pluginConfig.message] The commit message for the release.
+ * @param {String} [pluginConfig.pushStep] Step at which commits are pushed to git.
  */
 module.exports = pluginConfig => {
   const options = resolveConfig(pluginConfig);

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -1,0 +1,36 @@
+import test from 'ava';
+import {stub} from 'sinon';
+import publish from '../lib/publish';
+import {gitRepo} from './helpers/git-utils';
+
+test.beforeEach(t => {
+  // Stub the logger functions
+  t.context.log = stub();
+  t.context.logger = {log: t.context.log};
+});
+
+test("Skip push if pushStep is not 'publish'", async t => {
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  const pluginConfig = {};
+  const options = {repositoryUrl, branch: 'master'};
+  const env = {};
+  const lastRelease = {};
+  const nextRelease = {version: '2.0.0', gitTag: 'v2.0.0', notes: 'Test release note'};
+
+  await publish(pluginConfig, {cwd, env, options, lastRelease, nextRelease, logger: t.context.logger});
+
+  t.deepEqual(t.context.log.args, []);
+});
+
+test("Push if pushStep is 'publish'", async t => {
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  const pluginConfig = {pushStep: 'publish'};
+  const options = {repositoryUrl, branch: 'master'};
+  const env = {};
+  const lastRelease = {};
+  const nextRelease = {version: '2.0.0', gitTag: 'v2.0.0', notes: 'Test release note'};
+
+  await publish(pluginConfig, {cwd, env, options, lastRelease, nextRelease, logger: t.context.logger});
+
+  t.deepEqual(t.context.log.args[0], ['Published Git commit for: %s', 'v2.0.0']);
+});

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -59,6 +59,26 @@ test('Verify "assets" is an Array of Object with a glob Arrays in path property'
   t.notThrows(() => verify({assets}));
 });
 
+test('Verify "pushStep" as "prepare"', t => {
+  const pushStep = 'prepare';
+
+  t.notThrows(() => verify({pushStep}));
+});
+
+test('Verify "pushStep" as "publish"', t => {
+  const pushStep = 'publish';
+
+  t.notThrows(() => verify({pushStep}));
+});
+
+test('Throw SemanticReleaseError if "pushStep" option is "success"', t => {
+  const pushStep = 'success';
+  const [error] = t.throws(() => verify({pushStep}));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDPUSHSTEP');
+});
+
 test('Throw SemanticReleaseError if "message" option is not a String', t => {
   const message = 42;
   const [error] = t.throws(() => verify({message}));
@@ -83,6 +103,6 @@ test('Throw SemanticReleaseError if "message" option is a whitespace String', t 
   t.is(error.code, 'EINVALIDMESSAGE');
 });
 
-test('Verify undefined "message" and "assets"', t => {
+test('Verify undefined "message" and "assets" and "pushStep"', t => {
   t.notThrows(() => verify({}));
 });


### PR DESCRIPTION
This is optionally configurable through a new property called 'pushStep', which defaults to 'prepare', but accepts input as 'prepare' or 'publish'.

@pvdlg I intended to write a test to verify that `push` was called at the correct times, but I'm new to ava, and I didn't see an existing precedent on how to assert that "push" was called. I'll gladly add another test if you could nudge me in the right direction.