### PR TITLE
fix: message format does not take documented variables

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -62,7 +62,7 @@ module.exports = async (pluginConfig, context) => {
     debug('commited files: %o', filesToCommit);
     await commit(
       message
-        ? template(message)({branch: branch.name, lastRelease, nextRelease})
+        ? template(message)({branch, lastRelease, nextRelease,})
         : `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`,
       {env, cwd}
     );


### PR DESCRIPTION
BREAKING CHANGE: if you used `${branch}` in your message format,
you have to change it to `${branch.name}` as documented.