### PR TITLE
fix: fix ENAMETOOLONG for too big commit messages

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -1,5 +1,14 @@
+const os = require('os');
+const path = require('path');
+const fs = require('fs/promises');
+const crypto = require('crypto');
 const execa = require('execa');
 const debug = require('debug')('semantic-release:git');
+
+function _generateUniqueFilename() {
+  // -> https://stackoverflow.com/questions/23327010/how-to-generate-unique-id-with-node-js
+  return crypto.randomBytes(16).toString('hex');
+}
 
 /**
  * Retrieve the list of files modified on the local repository.
@@ -35,7 +44,14 @@ async function add(files, execaOptions) {
  * @throws {Error} if the commit failed.
  */
 async function commit(message, execaOptions) {
-  await execa('git', ['commit', '-m', message], execaOptions);
+  /* As messages can be arbitrarily long, we have to
+   write it to a tempfile to avoid ENAMETOOLONG on
+   poor systems not supporting "long" arguments */
+  const temporaryDir = os.tmpdir();
+  const temporaryMessageFileName = path.resolve(temporaryDir, _generateUniqueFilename());
+  await fs.writeFile(temporaryMessageFileName, message);
+  await execa('git', ['commit', '-F', temporaryMessageFileName], execaOptions);
+  await fs.unlink(temporaryMessageFileName);
 }
 
 /**

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -47,14 +47,18 @@ test('Returns [] if there is no modified files', async t => {
   await t.deepEqual(await getModifiedFiles({cwd}), []);
 });
 
-test('Commit added files', async t => {
+test('Commit added files with a huge message', async t => {
   // Create a git repository, set the current working directory at the root of the repo
   const {cwd} = await gitRepo();
   // Create files
   await outputFile(path.resolve(cwd, 'file1.js'), '');
   // Add files and commit
   await add(['.'], {cwd});
-  await commit('Test commit', {cwd});
+  // 1 MB message should break everything, ...
+  const hugeMessage = Array.from({length: 1024 * 1024})
+    .map((_, index) => (index % 72 ? 'z' : '\n'))
+    .join('');
+  await commit(hugeMessage, {cwd});
 
   await t.true((await gitGetCommits(undefined, {cwd})).length === 1);
 });


### PR DESCRIPTION
This PR allows running `semantic-release` to _reliably_ commit _arbitrary big_ commit messages. The old way of adding a commit message was by passing it simply along as a command line argument to `git commit -m ${message}` this will easily break for huge commit messages, depending on the platform:
* Windows seems to limit the **total** length of a program execution "string" (and thus a `execa()` call to _roughly_ 8 KB
* **and** there are limits for the total length per passed argument (on my system 128KB)

In practice one can easily hit those limits by having a moderate number of changes during releases, because _upstream_ in `semantic-release` for a default setup of `semantic-release/changelog`, `semantic-release/git` the generated changelog is added as a commit message.

The fix is, that the message is not passed as an argument, but a temporary file containing the message will be created and the file will be passed instead.

There are now some additional implications; whenever something goes wrong, there is the possibility that temporary files are not deleted, however as `os.tmpdir()` is used, this is something that the OS should deal with. Furthermore this now will break, if `os.tmpdir()` is not writeable by `semantic-release`. However I think it is a fair assumption, that `os.tmpdir()`is writeable - although an additional check could be added.

Whether this is a _breaking change_, this is left as ~an exercise for the astute reader~ something to be answerer by the maintainers. I'd say it is not, because it is _behaving as intended_. However this might break some pipelines, that have not `os.tmpdir()` _writeable_. I tested it on an Azure DevOps Windows hosted agent and I am pretty sure™ that in a sane default™  setup of build agents this should not pose any problems.

This is somehow related to: https://github.com/semantic-release/git/issues/91 (although I think the actual course for the problem there was the amout of changed files); at least it is giving the same error message.

There are further places in the code, where seemingly unrestricted data is passed via `execa()` that is suffering from the same problems (adding _a lot of files_ via [add](https://github.com/semantic-release/git/blob/09e00f98205e81e17ad9ec056a1efe20b42efb2a/lib/git.js#L25)), _however_ fixing this is not so easy, because `git add` does not support adding files from a _"list file"_. Possible solutions would be a _chunked_ adding (splitting the files by "length" and thus _multiple_ `git add` calls) - however this has further implications. I'd rather fix those problems in another PR if the maintainers are fine with this approach (or suggesting sth. better).
