### PR TITLE
Allow user action before push

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,11 @@ When configuring branches permission on a Git hosting service (e.g. [GitHub prot
 
 ### Options
 
-| Options   | Description                                                                                                                  | Default                                                                        |
-|-----------|------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
-| `message` | The message for the release commit. See [message](#message).                                                                 | `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`     |
-| `assets`  | Files to include in the release commit. Set to `false` to disable adding files to the release commit. See [assets](#assets). | `['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']` |
+| Options      | Description                                                                                                                  | Default                                                                        |
+|--------------|------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| `message`    | The message for the release commit. See [message](#message).                                                                 | `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`     |
+| `assets`     | Files to include in the release commit. Set to `false` to disable adding files to the release commit. See [assets](#assets). | `['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']` |
+| `prePushCmd` | The shell command to execute before push the new commit. See [prePushCmd](#prePushCmd). Set to `false` to disabled.          | `false`                                                                        |
 
 #### `message`
 
@@ -116,6 +117,20 @@ If a directory is configured, all the files under this directory and its childre
 `[['dist', '!**/*.css'], 'package.json']`: include `package.json` and all files in the `dist` directory and its sub-directories excluding the `css` files.
 
 `[['dist/**/*.{js,css}', '!**/*.min.*']]`: include all `js` and `css` files in the `dist` directory and its sub-directories excluding the minified version.
+
+#### `prePushCmd`
+
+| Command property | Description                                                                                                         |
+|------------------|---------------------------------------------------------------------------------------------------------------------|
+| `exit code`      | Any non `0` code is considered as an unexpected error and will stop the `semantic-release` execution with an error. |
+| `stdout`         | Can be used for logging.                                                                                            |
+| `stderr`         | Can be used for logging.                                                                                            |
+
+All parameters described in [message](#message) can be used in command value
+
+##### `prePushCmd` examples
+
+`"prePushCmd": "./pre-push.sh ${branch.name} ${branch.range} ${branch.prerelease}"`: Will execute `pre-push.sh` with 3 parameters (`branch.name`, `branch.range`, `branch.prerelease`)
 
 ### Examples
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function verifyConditions(pluginConfig, context) {
 
     pluginConfig.assets = defaultTo(pluginConfig.assets, preparePlugin.assets);
     pluginConfig.message = defaultTo(pluginConfig.message, preparePlugin.message);
+    pluginConfig.prePushCmd = defaultTo(pluginConfig.prePushCmd, preparePlugin.prePushCmd);
   }
 
   verifyGit(pluginConfig);

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -16,6 +16,14 @@ Your configuration for the \`assets\` option is \`${assets}\`.`,
     message: 'Invalid `message` option.',
     details: `The [message option](${linkify('README.md#message')}) option, if defined, must be a non empty \`String\`.
 
-Your configuration for the \`successComment\` option is \`${message}\`.`,
+Your configuration for the \`message\` option is \`${message}\`.`,
+  }),
+  EINVALIDPREPUSHCMD: ({prePushCmd}) => ({
+    message: 'Invalid `prePushCmd` option.',
+    details: `The [prePushCmd option](${linkify(
+      'README.md#prePushCmd'
+    )}) option, if defined, must be a non empty \`String\` or \`false\` to disable it.
+
+Your configuration for the \`prePushCmd\` option is \`${prePushCmd}\`.`,
   }),
 };

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -5,6 +5,7 @@ const pReduce = require('p-reduce');
 const debug = require('debug')('semantic-release:git');
 const resolveConfig = require('./resolve-config');
 const {getModifiedFiles, add, commit, push} = require('./git');
+const execa = require('execa');
 
 /**
  * Prepare a release commit including configurable files.
@@ -12,6 +13,7 @@ const {getModifiedFiles, add, commit, push} = require('./git');
  * @param {Object} pluginConfig The plugin configuration.
  * @param {String|Array<String>} [pluginConfig.assets] Files to include in the release commit. Can be files path or globs.
  * @param {String} [pluginConfig.message] The message for the release commit.
+ * @param {String|false} [pluginConfig.prePushCmd] The command to execute before push the newly created commit
  * @param {Object} context semantic-release context.
  * @param {Object} context.options `semantic-release` configuration.
  * @param {Object} context.lastRelease The last release.
@@ -27,8 +29,10 @@ module.exports = async (pluginConfig, context) => {
     lastRelease,
     nextRelease,
     logger,
+    stdout,
+    stderr,
   } = context;
-  const {message, assets} = resolveConfig(pluginConfig, logger);
+  const {message, assets, prePushCmd} = resolveConfig(pluginConfig);
 
   const modifiedFiles = await getModifiedFiles({env, cwd});
 
@@ -66,6 +70,20 @@ module.exports = async (pluginConfig, context) => {
         : `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`,
       {env, cwd}
     );
+
+    if (prePushCmd) {
+      logger.log('Executing prePushCmd: %s', prePushCmd);
+      const result = execa(template(prePushCmd)({branch: branch.name, lastRelease, nextRelease}), {
+        shell: true,
+        env,
+        cwd,
+      });
+      result.stdout.pipe(stdout, {end: false});
+      result.stderr.pipe(stderr, {end: false});
+
+      await result;
+    }
+
     await push(repositoryUrl, branch.name, {env, cwd});
     logger.log('Prepared Git release: %s', nextRelease.gitTag);
   }

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,10 +1,11 @@
 const {isNil, castArray} = require('lodash');
 
-module.exports = ({assets, message}) => ({
+module.exports = ({assets, message, prePushCmd}) => ({
   assets: isNil(assets)
     ? ['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']
     : assets
     ? castArray(assets)
     : assets,
   message,
+  prePushCmd: prePushCmd || false,
 });

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -13,16 +13,19 @@ const VALIDATORS = {
     isArrayOf(asset => isStringOrStringArray(asset) || (isPlainObject(asset) && isStringOrStringArray(asset.path)))
   ),
   message: isNonEmptyString,
+  prePushCmd: canBeDisabled(isNonEmptyString),
 };
 
 /**
  * Verify the commit `message` format and the `assets` option configuration:
  * - The commit `message`, is defined, must a non empty `String`.
  * - The `assets` configuration must be an `Array` of `String` (file path) or `false` (to disable).
+ * - The `prePushCmd` configuration must be a `String` or `false` (to disable).
  *
  * @param {Object} pluginConfig The plugin configuration.
  * @param {String|Array<String|Object>} [pluginConfig.assets] Files to include in the release commit. Can be files path or globs.
  * @param {String} [pluginConfig.message] The commit message for the release.
+ * @param {String|false} [pluginConfig.prePushCmd] The command to execute before push the newly created commit
  */
 module.exports = pluginConfig => {
   const options = resolveConfig(pluginConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "nyc": "15.1.0",
         "semantic-release": "19.0.2",
         "sinon": "13.0.1",
+        "stream-buffers": "3.0.2",
         "tempy": "1.0.1",
         "xo": "0.28.3"
       },
@@ -12427,6 +12428,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/stream-buffers": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
+      "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -23892,6 +23902,12 @@
           }
         }
       }
+    },
+    "stream-buffers": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.2.tgz",
+      "integrity": "sha512-DQi1h8VEBA/lURbSwFtEHnSTb9s2/pwLEaFuNhXwy1Dx3Sa0lOuYT2yNUr4/j2fs8oCAMANtrZ5OrPZtyVs3MQ==",
+      "dev": true
     },
     "stream-combiner2": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "nyc": "15.1.0",
     "semantic-release": "19.0.2",
     "sinon": "13.0.1",
+    "stream-buffers": "3.0.2",
     "tempy": "1.0.1",
     "xo": "0.28.3"
   },

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -83,6 +83,27 @@ test('Throw SemanticReleaseError if "message" option is a whitespace String', t 
   t.is(error.code, 'EINVALIDMESSAGE');
 });
 
-test('Verify undefined "message" and "assets"', t => {
+test('Throw SemanticReleaseError if "prePushCmd" option is not a String', t => {
+  const prePushCmd = 42;
+  const [error] = t.throws(() => verify({prePushCmd}));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDPREPUSHCMD');
+});
+
+test('Throw SemanticReleaseError if "prePushCmd" option is a whitespace String', t => {
+  const prePushCmd = '  \n \r ';
+  const [error] = t.throws(() => verify({prePushCmd}));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDPREPUSHCMD');
+});
+
+test('Verify empty string "prePushCmd" option', t => {
+  const prePushCmd = '';
+  t.notThrows(() => verify({prePushCmd}));
+});
+
+test('Verify undefined "message", "assets" and "prePushCmd"', t => {
   t.notThrows(() => verify({}));
 });


### PR DESCRIPTION

Let a change to users to execute a custom command before push.

Use case : Could be useful to handle branch-protection (with GH API)