### PR TITLE
feat: include parent directory in `getModifiedFiles`

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -1,6 +1,10 @@
 const execa = require('execa');
 const debug = require('debug')('semantic-release:git');
 
+async function showTopLevel(execaOptions) {
+  return (await execa('git', ['rev-parse', '--show-toplevel'], execaOptions)).stdout;
+}
+
 /**
  * Retrieve the list of files modified on the local repository.
  *
@@ -9,7 +13,8 @@ const debug = require('debug')('semantic-release:git');
  * @return {Array<String>} Array of modified files path.
  */
 async function getModifiedFiles(execaOptions) {
-  return (await execa('git', ['ls-files', '-m', '-o'], execaOptions)).stdout
+  const topLevel = await showTopLevel(execaOptions);
+  return (await execa('git', ['ls-files', '-m', '-o', topLevel], execaOptions)).stdout
     .split('\n')
     .map((file) => file.trim())
     .filter((file) => Boolean(file));

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -47,6 +47,25 @@ test('Returns [] if there is no modified files', async (t) => {
   await t.deepEqual(await getModifiedFiles({cwd}), []);
 });
 
+test('Get the modified files, including files in parent directories', async (t) => {
+  // Create a git repository, set the current working directory at the root of the repo
+  const {cwd} = await gitRepo();
+  // Create files
+  await outputFile(path.resolve(cwd, 'file1.js'), '');
+  await outputFile(path.resolve(cwd, 'dir/file2.js'), '');
+  // Add files and commit
+  await add(['.'], {cwd});
+  await commit('Test commit', {cwd});
+  // Update file1.js, dir/file2.js
+  await appendFile(path.resolve(cwd, 'file1.js'), 'Test content');
+  await appendFile(path.resolve(cwd, 'dir/file2.js'), 'Test content');
+
+  await t.deepEqual(
+    (await getModifiedFiles({cwd: path.resolve(cwd, 'dir')})).sort(),
+    ['../file1.js', 'file2.js'].sort()
+  );
+});
+
 test('Commit added files', async (t) => {
   // Create a git repository, set the current working directory at the root of the repo
   const {cwd} = await gitRepo();


### PR DESCRIPTION
This PR fixes #389.

For the following directory structure:

```
├── file1.js
└── dir
    ├── file2.js
    └── release.config.js
```

When running semantic-release from `dir`, changes to `file1.js` could not be added to assets using `../file1.js`.

This PR uses `git rev-parse --show-toplevel` to find the path of the top level of the git repo, then passes that path to `git ls-files -m -o` to get all modified files in the repo, relative to the current working directory.