### PR TITLE
feat: add forcePush option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
     "@semantic-release/release-notes-generator",
     ["@semantic-release/git", {
       "assets": ["dist/**/*.{js,css}", "docs", "package.json"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+      "forcePush": true
     }]
   ]
 }
@@ -69,6 +70,7 @@ When configuring branches permission on a Git hosting service (e.g. [GitHub prot
 |-----------|------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
 | `message` | The message for the release commit. See [message](#message).                                                                 | `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`     |
 | `assets`  | Files to include in the release commit. Set to `false` to disable adding files to the release commit. See [assets](#assets). | `['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']` |
+| `forcePush`  | Optional flag of `true` or `false` that defines whether the push has `--force`. | `false` |
 
 #### `message`
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ When configuring branches permission on a Git hosting service (e.g. [GitHub prot
 |-----------|------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
 | `message` | The message for the release commit. See [message](#message).                                                                 | `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`     |
 | `assets`  | Files to include in the release commit. Set to `false` to disable adding files to the release commit. See [assets](#assets). | `['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']` |
-| `forcePush`  | Optional flag of `true` or `false` that defines whether the push has `--force`. | `false` |
+| `forcePush`  | Optional boolean flag of `true` or `false` that defines whether the push has `--force`. | `false` |
 
 #### `message`
 

--- a/index.js
+++ b/index.js
@@ -6,13 +6,14 @@ let verified;
 
 function verifyConditions(pluginConfig, context) {
   const {options} = context;
-  // If the Git prepare plugin is used and has `assets` or `message` configured, validate them now in order to prevent any release if the configuration is wrong
+  // If the Git prepare plugin is used and has `assets` or `message` or `force` configured, validate them now in order to prevent any release if the configuration is wrong
   if (options.prepare) {
     const preparePlugin =
       castArray(options.prepare).find((config) => config.path && config.path === '@semantic-release/git') || {};
 
     pluginConfig.assets = defaultTo(pluginConfig.assets, preparePlugin.assets);
     pluginConfig.message = defaultTo(pluginConfig.message, preparePlugin.message);
+    pluginConfig.force = defaultTo(pluginConfig.force, preparePlugin.force);
   }
 
   verifyGit(pluginConfig);

--- a/index.js
+++ b/index.js
@@ -6,14 +6,14 @@ let verified;
 
 function verifyConditions(pluginConfig, context) {
   const {options} = context;
-  // If the Git prepare plugin is used and has `assets` or `message` or `force` configured, validate them now in order to prevent any release if the configuration is wrong
+  // If the Git prepare plugin is used and has `assets` or `message` or `forcePush` configured, validate them now in order to prevent any release if the configuration is wrong
   if (options.prepare) {
     const preparePlugin =
       castArray(options.prepare).find((config) => config.path && config.path === '@semantic-release/git') || {};
 
     pluginConfig.assets = defaultTo(pluginConfig.assets, preparePlugin.assets);
     pluginConfig.message = defaultTo(pluginConfig.message, preparePlugin.message);
-    pluginConfig.force = defaultTo(pluginConfig.force, preparePlugin.force);
+    pluginConfig.forcePush = defaultTo(pluginConfig.forcePush, preparePlugin.forcePush);
   }
 
   verifyGit(pluginConfig);

--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -18,4 +18,10 @@ Your configuration for the \`assets\` option is \`${assets}\`.`,
 
 Your configuration for the \`successComment\` option is \`${message}\`.`,
   }),
+  EINVALIDFORCEPUSH: ({forcePush}) => ({
+    message: 'Invalid `forcePush` option.',
+    details: `The [forcePush option](${linkify('README.md#usage')}) option, if defined, must be a \`Boolean\`.
+
+Your configuration for the \`forcePush\` option is \`${forcePush}\`.`,
+  }),
 };

--- a/lib/git.js
+++ b/lib/git.js
@@ -49,7 +49,12 @@ async function commit(message, execaOptions) {
  * @throws {Error} if the push failed.
  */
 async function push(origin, branch, execaOptions, forcePush = false) {
-  await execa('git', ['push', '--tags', origin, `HEAD:${branch}`, forcePush === true ? '--force' : ''], execaOptions);
+  const gitFlags = ['push', '--tags', origin, `HEAD:${branch}`];
+  if (forcePush === true) {
+    gitFlags.push('--force');
+  }
+
+  await execa('git', gitFlags, execaOptions);
 }
 
 /**

--- a/lib/git.js
+++ b/lib/git.js
@@ -44,11 +44,12 @@ async function commit(message, execaOptions) {
  * @param {String} origin The remote repository URL.
  * @param {String} branch The branch to push.
  * @param {Object} [execaOpts] Options to pass to `execa`.
+ * @param {Boolean} [forcePush] Whether to do a force push or not.
  *
  * @throws {Error} if the push failed.
  */
-async function push(origin, branch, execaOptions) {
-  await execa('git', ['push', '--tags', origin, `HEAD:${branch}`], execaOptions);
+async function push(origin, branch, execaOptions, forcePush = false) {
+  await execa('git', ['push', '--tags', origin, `HEAD:${branch}`, forcePush === true ? '--force' : ''], execaOptions);
 }
 
 /**

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -12,6 +12,7 @@ const {getModifiedFiles, add, commit, push} = require('./git.js');
  * @param {Object} pluginConfig The plugin configuration.
  * @param {String|Array<String>} [pluginConfig.assets] Files to include in the release commit. Can be files path or globs.
  * @param {String} [pluginConfig.message] The message for the release commit.
+ * @param {Boolean} [pluginConfig.forcePush] The message for the release commit.
  * @param {Object} context semantic-release context.
  * @param {Object} context.options `semantic-release` configuration.
  * @param {Object} context.lastRelease The last release.
@@ -28,7 +29,7 @@ module.exports = async (pluginConfig, context) => {
     nextRelease,
     logger,
   } = context;
-  const {message, assets} = resolveConfig(pluginConfig, logger);
+  const {message, assets, forcePush} = resolveConfig(pluginConfig, logger);
 
   const modifiedFiles = await getModifiedFiles({env, cwd});
 
@@ -66,7 +67,7 @@ module.exports = async (pluginConfig, context) => {
         : `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`,
       {env, cwd}
     );
-    await push(repositoryUrl, branch.name, {env, cwd});
+    await push(repositoryUrl, branch.name, {env, cwd}, forcePush);
     logger.log('Prepared Git release: %s', nextRelease.gitTag);
   }
 };

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,10 +1,11 @@
 const {isNil, castArray} = require('lodash');
 
-module.exports = ({assets, message}) => ({
+module.exports = ({assets, message, forcePush}) => ({
   assets: isNil(assets)
     ? ['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']
     : assets
     ? castArray(assets)
     : assets,
   message,
+  forcePush: isNil(forcePush) ? false : forcePush,
 });

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -10,22 +10,26 @@ const isStringOrStringArray = (value) => {
 
 const isArrayOf = (validator) => (array) => isArray(array) && array.every((value) => validator(value));
 const canBeDisabled = (validator) => (value) => value === false || validator(value);
+const BooleanOrNil = (value) => value === false || value === true || isNil(value);
 
 const VALIDATORS = {
   assets: canBeDisabled(
     isArrayOf((asset) => isStringOrStringArray(asset) || (isPlainObject(asset) && isStringOrStringArray(asset.path)))
   ),
   message: isNonEmptyString,
+  forcePush: BooleanOrNil,
 };
 
 /**
- * Verify the commit `message` format and the `assets` option configuration:
+ * Verify the commit `message` format, the `assets`, and the `forcePush` option configuration:
  * - The commit `message`, is defined, must a non empty `String`.
  * - The `assets` configuration must be an `Array` of `String` (file path) or `false` (to disable).
+ * - The `forcePush` configuration must be a `Boolan` or empty/nil.
  *
  * @param {Object} pluginConfig The plugin configuration.
  * @param {String|Array<String|Object>} [pluginConfig.assets] Files to include in the release commit. Can be files path or globs.
  * @param {String} [pluginConfig.message] The commit message for the release.
+ * @param {Boolean} [pluginConfig.forcePush] Should the push be ran with `--force` (true/false).
  */
 module.exports = (pluginConfig) => {
   const options = resolveConfig(pluginConfig);

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -86,3 +86,13 @@ test('Push commit to remote repository', async (t) => {
 
   t.is(await gitRemoteHead(repositoryUrl, {cwd}), hash);
 });
+
+test('Force push commit to remote repository', async (t) => {
+  // Create a git repository with a remote, set the current working directory at the root of the repo
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  const [{hash}] = await gitCommits(['Test commit'], {cwd});
+
+  await push(repositoryUrl, 'master', {cwd}, true);
+
+  t.is(await gitRemoteHead(repositoryUrl, {cwd}), hash);
+});

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -215,6 +215,22 @@ async function gitPush(repositoryUrl, branch, execaOptions) {
   await execa('git', ['push', '--tags', repositoryUrl, `HEAD:${branch}`], execaOptions);
 }
 
+/**
+ * Force push to the remote repository.
+ *
+ * @param {String} repositoryUrl The remote repository URL.
+ * @param {String} branch The branch to push.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ * @param {Boolean} [forcepush] Whether to force push.
+ */
+async function gitForcePush(repositoryUrl, branch, execaOptions, forcePush = false) {
+  await execa(
+    'git',
+    ['push', '--tags', repositoryUrl, `HEAD:${branch}`, forcePush === true ? '--force' : ''],
+    execaOptions
+  );
+}
+
 module.exports = {
   gitRepo,
   initBareRepo,
@@ -229,4 +245,5 @@ module.exports = {
   gitCommitedFiles,
   gitAdd,
   gitPush,
+  gitForcePush,
 };

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -224,11 +224,12 @@ async function gitPush(repositoryUrl, branch, execaOptions) {
  * @param {Boolean} [forcepush] Whether to force push.
  */
 async function gitForcePush(repositoryUrl, branch, execaOptions, forcePush = false) {
-  await execa(
-    'git',
-    ['push', '--tags', repositoryUrl, `HEAD:${branch}`, forcePush === true ? '--force' : ''],
-    execaOptions
-  );
+  const gitFlags = ['push', '--tags', repositoryUrl, `HEAD:${branch}`];
+  if (forcePush === true) {
+    gitFlags.push('--force');
+  }
+
+  await execa('git', gitFlags, execaOptions);
 }
 
 module.exports = {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -58,6 +58,41 @@ test('Prepare from a shallow clone', async (t) => {
   t.is(commit.gitTags, `(HEAD -> ${branch.name})`);
 });
 
+test('Prepare from a shallow clone with force push', async (t) => {
+  const branch = {name: 'master'};
+  let {cwd, repositoryUrl} = await gitRepo(true);
+  await outputFile(path.resolve(cwd, 'package.json'), "{name: 'test-package', version: '1.0.0'}");
+  await outputFile(path.resolve(cwd, 'dist/file.js'), 'Initial content');
+  await outputFile(path.resolve(cwd, 'dist/file.css'), 'Initial content');
+  await add('.', {cwd});
+  await gitCommits(['First'], {cwd});
+  await gitTagVersion('v1.0.0', undefined, {cwd});
+  await push(repositoryUrl, branch.name, {cwd}, true);
+  cwd = await gitShallowClone(repositoryUrl);
+  await outputFile(path.resolve(cwd, 'package.json'), "{name: 'test-package', version: '2.0.0'}");
+  await outputFile(path.resolve(cwd, 'dist/file.js'), 'Updated content');
+  await outputFile(path.resolve(cwd, 'dist/file.css'), 'Updated content');
+
+  const nextRelease = {version: '2.0.0', gitTag: 'v2.0.0', notes: 'Version 2.0.0 changelog'};
+  const pluginConfig = {
+    message: `Release version \${nextRelease.version} from branch \${branch}\n\n\${nextRelease.notes}`,
+    assets: '**/*.{js,json}',
+  };
+  await t.context.m.prepare(pluginConfig, {
+    cwd,
+    branch,
+    options: {repositoryUrl},
+    nextRelease,
+    logger: t.context.logger,
+  });
+
+  t.deepEqual((await gitCommitedFiles('HEAD', {cwd})).sort(), ['dist/file.js', 'package.json'].sort());
+  const [commit] = await gitGetCommits(undefined, {cwd});
+  t.is(commit.subject, `Release version ${nextRelease.version} from branch ${branch.name}`);
+  t.is(commit.body, `${nextRelease.notes}\n`);
+  t.is(commit.gitTags, `(HEAD -> ${branch.name})`);
+});
+
 test('Prepare from a detached head repository', async (t) => {
   const branch = {name: 'master'};
   let {cwd, repositoryUrl} = await gitRepo(true);
@@ -68,6 +103,41 @@ test('Prepare from a detached head repository', async (t) => {
   const [{hash}] = await gitCommits(['First'], {cwd});
   await gitTagVersion('v1.0.0', undefined, {cwd});
   await push(repositoryUrl, branch.name, {cwd});
+  cwd = await gitDetachedHead(repositoryUrl, hash);
+  await outputFile(path.resolve(cwd, 'package.json'), "{name: 'test-package', version: '2.0.0'}");
+  await outputFile(path.resolve(cwd, 'dist/file.js'), 'Updated content');
+  await outputFile(path.resolve(cwd, 'dist/file.css'), 'Updated content');
+
+  const nextRelease = {version: '2.0.0', gitTag: 'v2.0.0', notes: 'Version 2.0.0 changelog'};
+  const pluginConfig = {
+    message: `Release version \${nextRelease.version} from branch \${branch}\n\n\${nextRelease.notes}`,
+    assets: '**/*.{js,json}',
+  };
+  await t.context.m.prepare(pluginConfig, {
+    cwd,
+    branch,
+    options: {repositoryUrl},
+    nextRelease,
+    logger: t.context.logger,
+  });
+
+  t.deepEqual((await gitCommitedFiles('HEAD', {cwd})).sort(), ['dist/file.js', 'package.json'].sort());
+  const [commit] = await gitGetCommits(undefined, {cwd});
+  t.is(commit.subject, `Release version ${nextRelease.version} from branch ${branch.name}`);
+  t.is(commit.body, `${nextRelease.notes}\n`);
+  t.is(commit.gitTags, `(HEAD)`);
+});
+
+test('Prepare from a detached head repository with force pushing', async (t) => {
+  const branch = {name: 'master'};
+  let {cwd, repositoryUrl} = await gitRepo(true);
+  await outputFile(path.resolve(cwd, 'package.json'), "{name: 'test-package', version: '1.0.0'}");
+  await outputFile(path.resolve(cwd, 'dist/file.js'), 'Initial content');
+  await outputFile(path.resolve(cwd, 'dist/file.css'), 'Initial content');
+  await add('.', {cwd});
+  const [{hash}] = await gitCommits(['First'], {cwd});
+  await gitTagVersion('v1.0.0', undefined, {cwd});
+  await push(repositoryUrl, branch.name, {cwd}, true);
   cwd = await gitDetachedHead(repositoryUrl, hash);
   await outputFile(path.resolve(cwd, 'package.json'), "{name: 'test-package', version: '2.0.0'}");
   await outputFile(path.resolve(cwd, 'dist/file.js'), 'Updated content');
@@ -119,13 +189,18 @@ test('Throw SemanticReleaseError if prepare config is invalid', (t) => {
 test('Throw SemanticReleaseError if config is invalid', (t) => {
   const message = 42;
   const assets = true;
+  const forcePush = 'failure';
 
   const errors = [
-    ...t.throws(() => t.context.m.verifyConditions({message, assets}, {options: {}, logger: t.context.logger})),
+    ...t.throws(() =>
+      t.context.m.verifyConditions({message, assets, forcePush}, {options: {}, logger: t.context.logger})
+    ),
   ];
 
   t.is(errors[0].name, 'SemanticReleaseError');
   t.is(errors[0].code, 'EINVALIDASSETS');
   t.is(errors[1].name, 'SemanticReleaseError');
   t.is(errors[1].code, 'EINVALIDMESSAGE');
+  t.is(errors[2].name, 'SemanticReleaseError');
+  t.is(errors[2].code, 'EINVALIDFORCEPUSH');
 });

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -77,6 +77,7 @@ test('Prepare from a shallow clone with force push', async (t) => {
   const pluginConfig = {
     message: `Release version \${nextRelease.version} from branch \${branch}\n\n\${nextRelease.notes}`,
     assets: '**/*.{js,json}',
+    forcePush: true,
   };
   await t.context.m.prepare(pluginConfig, {
     cwd,
@@ -147,6 +148,7 @@ test('Prepare from a detached head repository with force pushing', async (t) => 
   const pluginConfig = {
     message: `Release version \${nextRelease.version} from branch \${branch}\n\n\${nextRelease.notes}`,
     assets: '**/*.{js,json}',
+    forcePush: true,
   };
   await t.context.m.prepare(pluginConfig, {
     cwd,

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -214,6 +214,30 @@ test('Include deleted files in release commit', async (t) => {
   t.deepEqual(t.context.log.args[0], ['Found %d file(s) to commit', 1]);
 });
 
+test('Include deleted files in release commit with force push', async (t) => {
+  const {cwd, repositoryUrl} = await gitRepo(true);
+  const pluginConfig = {
+    assets: ['file1.js'],
+  };
+  const branch = {name: 'master'};
+  const options = {repositoryUrl};
+  const env = {};
+  const lastRelease = {};
+  const nextRelease = {version: '2.0.0', gitTag: 'v2.0.0'};
+  await outputFile(path.resolve(cwd, 'file1.js'), 'Test content');
+  await outputFile(path.resolve(cwd, 'file2.js'), 'Test content');
+
+  await gitAdd(['file1.js', 'file2.js'], {cwd, env});
+  await gitCommits(['Add file1.js and file2.js'], {cwd, env});
+  await gitPush(repositoryUrl, 'master', {cwd, env}, true);
+
+  await remove(path.resolve(cwd, 'file1.js'));
+  await prepare(pluginConfig, {cwd, env, options, branch, lastRelease, nextRelease, logger: t.context.logger});
+
+  t.deepEqual((await gitCommitedFiles('HEAD', {cwd, env})).sort(), ['file1.js'].sort());
+  t.deepEqual(t.context.log.args[0], ['Found %d file(s) to commit', 1]);
+});
+
 test('Set the commit author and committer name/email based on environment variables', async (t) => {
   const {cwd, repositoryUrl} = await gitRepo(true);
   const branch = {name: 'master'};

--- a/test/verify.test.js
+++ b/test/verify.test.js
@@ -83,6 +83,26 @@ test('Throw SemanticReleaseError if "message" option is a whitespace String', (t
   t.is(error.code, 'EINVALIDMESSAGE');
 });
 
-test('Verify undefined "message" and "assets"', (t) => {
+test('Throw SemanticReleaseError if "forcePush" option is not a Boolean', (t) => {
+  const forcePush = 'failure';
+  const [error] = t.throws(() => verify({forcePush}));
+
+  t.is(error.name, 'SemanticReleaseError');
+  t.is(error.code, 'EINVALIDFORCEPUSH');
+});
+
+test('Verify "forcePush" is explicitly disabled (falsy)', (t) => {
+  const forcePush = false;
+
+  t.notThrows(() => verify({forcePush}));
+});
+
+test('Verify "forcePush" is an explicitly enabled', (t) => {
+  const forcePush = true;
+
+  t.notThrows(() => verify({forcePush}));
+});
+
+test('Verify undefined "message" and "assets" and "forcePush"', (t) => {
   t.notThrows(() => verify({}));
 });


### PR DESCRIPTION
This PR provides the option to pass the `--force` flag as defined in #395. This is a non-breaking change, the default behavior is what exists now, but can now be changed by passing `forcePush: true` into the config.