### PR TITLE
fix: allow assets to be false

### DIFF
--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -32,29 +32,32 @@ module.exports = async (pluginConfig, context) => {
 
   const modifiedFiles = await getModifiedFiles({env, cwd});
 
-  const filesToCommit = uniq(
-    await pReduce(
-      assets.map((asset) => (!isArray(asset) && isPlainObject(asset) ? asset.path : asset)),
-      async (result, asset) => {
-        const glob = castArray(asset);
-        let nonegate;
-        // Skip solo negated pattern (avoid to include every non js file with `!**/*.js`)
-        if (glob.length <= 1 && glob[0].startsWith('!')) {
-          nonegate = true;
-          debug(
-            'skipping the negated glob %o as its alone in its group and would retrieve a large amount of files ',
-            glob[0]
-          );
-        }
+  const filesToCommit =
+    assets && assets.length > 0
+      ? uniq(
+          await pReduce(
+            assets.map((asset) => (!isArray(asset) && isPlainObject(asset) ? asset.path : asset)),
+            async (result, asset) => {
+              const glob = castArray(asset);
+              let nonegate;
+              // Skip solo negated pattern (avoid to include every non js file with `!**/*.js`)
+              if (glob.length <= 1 && glob[0].startsWith('!')) {
+                nonegate = true;
+                debug(
+                  'skipping the negated glob %o as its alone in its group and would retrieve a large amount of files ',
+                  glob[0]
+                );
+              }
 
-        return [
-          ...result,
-          ...micromatch(modifiedFiles, await dirGlob(glob, {cwd}), {dot: true, nonegate, cwd, expand: true}),
-        ];
-      },
-      []
-    )
-  );
+              return [
+                ...result,
+                ...micromatch(modifiedFiles, await dirGlob(glob, {cwd}), {dot: true, nonegate, cwd, expand: true}),
+              ];
+            },
+            []
+          )
+        )
+      : [];
 
   if (filesToCommit.length > 0) {
     logger.log('Found %d file(s) to commit', filesToCommit.length);

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -133,15 +133,6 @@ test('Commit no files when "assets" is false', async (t) => {
   const env = {};
   const lastRelease = {};
   const nextRelease = {version: '2.0.0', gitTag: 'v2.0.0'};
-  // Create .gitignore to ignore file5.js
-  await outputFile(path.resolve(cwd, '.gitignore'), 'file5.js');
-  await outputFile(path.resolve(cwd, 'file1.js'), 'Test content');
-  await outputFile(path.resolve(cwd, 'dir/file2.js'), 'Test content');
-  await outputFile(path.resolve(cwd, 'dir/file3.css'), 'Test content');
-  await outputFile(path.resolve(cwd, 'file4.js'), 'Test content');
-  await outputFile(path.resolve(cwd, 'file5.js'), 'Test content');
-  await outputFile(path.resolve(cwd, 'dir2/file6.js'), 'Test content');
-  await outputFile(path.resolve(cwd, 'dir2/file7.css'), 'Test content');
 
   await prepare(pluginConfig, {cwd, env, options, branch, lastRelease, nextRelease, logger: t.context.logger});
 

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -136,11 +136,6 @@ test('Commit no files when "assets" is false', async (t) => {
 
   await prepare(pluginConfig, {cwd, env, options, branch, lastRelease, nextRelease, logger: t.context.logger});
 
-  // Verify file2 and file1 have been commited
-  // file4.js is excluded as no glob matching
-  // file3.css is ignored due to the negative glob '!dir/*.css'
-  // file5.js is not ignored even if it's in the .gitignore
-  // file6.js and file7.css are included because dir2 is expanded
   t.deepEqual((await gitCommitedFiles('HEAD', {cwd, env})).sort(), []);
 });
 


### PR DESCRIPTION
Fixes #280.

If `assets` is falsy or doesn't have a truthy `.length`, then we assume it results in an empty array.