### PR TITLE
Add config to skip git push

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ When configuring branches permission on a Git hosting service (e.g. [GitHub prot
 |-----------|------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
 | `message` | The message for the release commit. See [message](#message).                                                                 | `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`     |
 | `assets`  | Files to include in the release commit. Set to `false` to disable adding files to the release commit. See [assets](#assets). | `['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']` |
+| `enablePush` | Enable or disable pushing to the remote repository | `true` |
 
 #### `message`
 

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -68,6 +68,8 @@ module.exports = async (pluginConfig, context) => {
     );
     if (enablePush) {
       await push(repositoryUrl, branch.name, {env, cwd});
+    } else {
+      logger.log('Skipping push');
     }
 
     logger.log('Prepared Git release: %s', nextRelease.gitTag);

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -28,7 +28,7 @@ module.exports = async (pluginConfig, context) => {
     nextRelease,
     logger,
   } = context;
-  const {message, assets} = resolveConfig(pluginConfig, logger);
+  const {message, assets, enablePush} = resolveConfig(pluginConfig, logger);
 
   const modifiedFiles = await getModifiedFiles({env, cwd});
 
@@ -66,7 +66,10 @@ module.exports = async (pluginConfig, context) => {
         : `chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}`,
       {env, cwd}
     );
-    await push(repositoryUrl, branch.name, {env, cwd});
+    if (enablePush) {
+      await push(repositoryUrl, branch.name, {env, cwd});
+    }
+
     logger.log('Prepared Git release: %s', nextRelease.gitTag);
   }
 };

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,10 +1,11 @@
 const {isNil, castArray} = require('lodash');
 
-module.exports = ({assets, message}) => ({
+module.exports = ({assets, message, enablePush}) => ({
   assets: isNil(assets)
     ? ['CHANGELOG.md', 'package.json', 'package-lock.json', 'npm-shrinkwrap.json']
     : assets
     ? castArray(assets)
     : assets,
   message,
+  enablePush: isNil(enablePush) ? true : enablePush,
 });

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,4 +1,4 @@
-const {isString, isNil, isArray, isPlainObject} = require('lodash');
+const {isString, isNil, isArray, isPlainObject, isBoolean} = require('lodash');
 const AggregateError = require('aggregate-error');
 const getError = require('./get-error.js');
 const resolveConfig = require('./resolve-config.js');
@@ -16,6 +16,7 @@ const VALIDATORS = {
     isArrayOf((asset) => isStringOrStringArray(asset) || (isPlainObject(asset) && isStringOrStringArray(asset.path)))
   ),
   message: isNonEmptyString,
+  enablePush: canBeDisabled((value) => isBoolean(value)),
 };
 
 /**

--- a/test/helpers/git-utils.js
+++ b/test/helpers/git-utils.js
@@ -167,6 +167,21 @@ async function gitRemoteHead(repositoryUrl, execaOptions) {
 }
 
 /**
+ * Get the first commit sha referenced by the tag `tagName` in the local repository.
+ *
+ * @param {String} repositoryUrl The repository remote URL.
+ * @param {Object} [execaOpts] Options to pass to `execa`.
+ *
+ * @return {String} The HEAD sha of the local repository.
+ */
+async function gitShowHead(execaOptions) {
+  return (await execa('git', ['show', 'HEAD', '--quiet'], execaOptions)).stdout
+    .split('\n')
+    .filter((show) => show.startsWith('commit'))
+    .map((commit) => commit.match(/^commit (?<commit>\S+)/)[1])[0];
+}
+
+/**
  *Get the list of staged files.
  *
  * @param {Object} [execaOpts] Options to pass to `execa`.
@@ -225,6 +240,7 @@ module.exports = {
   gitShallowClone,
   gitDetachedHead,
   gitRemoteHead,
+  gitShowHead,
   gitStaged,
   gitCommitedFiles,
   gitAdd,

--- a/test/prepare.test.js
+++ b/test/prepare.test.js
@@ -3,7 +3,16 @@ const test = require('ava');
 const {outputFile, remove} = require('fs-extra');
 const {stub} = require('sinon');
 const prepare = require('../lib/prepare.js');
-const {gitRepo, gitGetCommits, gitCommitedFiles, gitAdd, gitCommits, gitPush, gitRemoteHead, gitShowHead} = require('./helpers/git-utils.js');
+const {
+  gitRepo,
+  gitGetCommits,
+  gitCommitedFiles,
+  gitAdd,
+  gitCommits,
+  gitPush,
+  gitRemoteHead,
+  gitShowHead,
+} = require('./helpers/git-utils.js');
 
 test.beforeEach((t) => {
   // Stub the logger functions
@@ -243,7 +252,7 @@ test('Set the commit author and committer name/email based on environment variab
 test('Push commit to remote by default', async (t) => {
   const {cwd, repositoryUrl} = await gitRepo(true);
   const pluginConfig = {
-    enablePush: true
+    enablePush: true,
   };
   const branch = {name: 'master'};
   const options = {repositoryUrl};
@@ -257,16 +266,13 @@ test('Push commit to remote by default', async (t) => {
   // Verify the files that have been commited
   t.deepEqual(await gitCommitedFiles('HEAD', {cwd, env}), ['CHANGELOG.md']);
   // Verify the commit as been pushed
-  t.deepEqual(
-    await gitRemoteHead(repositoryUrl, {cwd, env}),
-    await gitShowHead({cwd, env})
-  );
+  t.deepEqual(await gitRemoteHead(repositoryUrl, {cwd, env}), await gitShowHead({cwd, env}));
 });
 
 test('Skip push commit when enable push is false', async (t) => {
   const {cwd, repositoryUrl} = await gitRepo(true);
   const pluginConfig = {
-    enablePush: false
+    enablePush: false,
   };
   const branch = {name: 'master'};
   const options = {repositoryUrl};
@@ -280,10 +286,7 @@ test('Skip push commit when enable push is false', async (t) => {
   // Verify the files that have been commited
   t.deepEqual(await gitCommitedFiles('HEAD', {cwd, env}), ['CHANGELOG.md']);
   // Verify the commit as been not been pushed
-  t.notDeepEqual(
-    await gitRemoteHead(repositoryUrl, {cwd, env}),
-    await gitShowHead({cwd, env})
-  );
+  t.notDeepEqual(await gitRemoteHead(repositoryUrl, {cwd, env}), await gitShowHead({cwd, env}));
 });
 
 test('Skip negated pattern if its alone in its group', async (t) => {


### PR DESCRIPTION
This MR allow someone to skip the git push to the remote repository with a config.

By default the push stay enable.

Why ? 
Someone running semantic-release in a monorepo could need to do a release on every affected package and after that do the push manually. Without this option semantic-release/git work on the first release but break on every subsequent release because git isnt up to date with master.

Feel free to reach out if you need anything done to get the MR merged !

<3