### PR TITLE
Security: Argument Injection in git add command

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -26,7 +26,7 @@ export async function getModifiedFiles(execaOptions) {
 export async function add(files, execaOptions) {
   const shell = await execa(
     "git",
-    ["add", "--force", "--ignore-errors", ...files],
+    ["add", "--force", "--ignore-errors", "--", ...files],
     { ...execaOptions, reject: false },
   );
   debug("add file to git index", shell);


### PR DESCRIPTION
## Summary

Security: Argument Injection in git add command

## Problem

**Severity**: `High` | **File**: `lib/git.js:L26`

In `lib/git.js`, the `add` function passes the `files` array directly into the `execa` arguments for `git add`. If a file path contains strings that start with `-` (e.g., `-u` or `--all`), `git` may interpret them as command-line options rather than file paths. This can lead to argument injection, potentially allowing unintended files to be staged or other git options to be triggered.

## Solution

Prepend `--` to the git arguments before the file list to explicitly mark the end of options and treat all subsequent arguments as file paths. For example: `['add', '--force', '--ignore-errors', '--', ...files]`.

## Changes

- `lib/git.js` (modified)